### PR TITLE
Change version from `master` to `main`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ RUN wget $(wget -O- https://raw.githubusercontent.com/Stremio/stremio-shell/mast
 # Main image
 FROM base AS final
 
-ARG VERSION=master
+ARG VERSION=main
 LABEL org.opencontainers.image.source=https://github.com/tsaridas/stremio-docker
 LABEL org.opencontainers.image.description="Stremio Web Player and Server"
 LABEL org.opencontainers.image.licenses=MIT


### PR DESCRIPTION
On stremio-web, the master branch hasn't been updated in 5 years. The main branch on the other hand is 3 years old. Unless you'd like to be using `development` (their latest bleeding edge branch) it's probably better to stick to the standard `main` branch.