### PR TITLE
Add Compose config for Stremio with Traefik + optional VPN support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.github
+.history
+*.swp

--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,69 @@
+# Stremio Configuration
+# ===================
+#
+# Custom configuration folder path
+#APP_PATH=$HOME/.stremio-server
+# Custom certificate filename (used with DOMAIN)
+#CERT_FILE=
+# IP address for HTTPS cert generation (default: none).
+# You can set your public/LAN IP address here.
+# 0.0.0.0 will auto-resolve to your public IP.
+# When using VPN's (like gluetun): You CANNOT auto-resolve IP addresses using 0.0.0.0 with Traefik, UNLESS traefik is ALSO using the VPN.
+#IPADDRESS=0.0.0.0
+
+# Force a streaming server URL in the 'streaming' settings tab of the web UI.
+# Note: Anytime this is changed on the frontend by the user, the page will redirect automatically and reset to this URL.
+# This prevents the user from changing it completely.
+#SERVER_URL=https://stremio.your_domain.com
+# Alternatively, use stremio's own ngrok-style server URL.
+# The 0-0-0-0 will auto-resolve to your public IP.
+# When using VPN's (like gluetun): You CANNOT auto-resolve IP addresses using 0-0-0-0 with Traefik, UNLESS traefik is ALSO using the VPN.
+#SERVER_URL=https://0-0-0-0.519b6502d940.stremio.rocks:12470/
+
+# Where the streaming server will redirect to.
+# Defaults to https://app.strem.io/shell-v4.4/
+# NOTE: ?streamingServer=<your_streaming_server> is automatically appended to whatever WEBUI_LOCATION is set to. This append is ONLY compatible with the v4 shell.
+# <your_streaming_server> i.e. your https://IPADDRESS:12470 or https://stremio.your_domain.com. The same thing you may or may not have configured to SERVER_URL
+WEBUI_LOCATION=https://stremio-web.${DOMAIN}/shell/
+
+# Disable chromecast support if you don't plan on using this container across your LAN.
+# This is a workaround for the "No devices found" error in the web UI.
+CASTING_DISABLED: 1
+# Lookup 'cors' on google but I've only ever tested this with CORS enabled. I've no idea if stremio or the streaming server need to access non-contextual URLs, let alone its addons, so best to just enable it.
+NO_CORS: 0
+ 
+# Traefik/Compose Variables
+# ===================
+#
+# Your root domain for subdomain-based routing via Traefik. Subdomains will be named automatically based on each container name.
+DOMAIN=example.com
+# DuckDNS API token, for DNS challenges across Traefik. Also used for DNS records.
+DUCKDNS_TOKEN=
+# Email for ACME certificate resolver in Traefik
+ACME_RESOLVER_EMAIL=your_email@example.com
+# Email for Let's Encrypt certificate registration
+LETS_ENCRYPT_EMAIL=your_email@example.com
+
+
+
+
+
+# The rest of the env variables are OPTIONAL.
+#
+# Path Configurations
+# ==================
+CONFIG_PATH=./configs                       # Root path for configuration volume mounts
+CONFIGS_PATH=./configs                      # Path for Traefik configuration files
+CERTS_PATH=./certs                         # Path for storing TLS certificates
+SRC_PATH=./src                             # Path to Stremio Docker build source directory
+TRAEFIK_INTERNAL_CERTS_DIR=/certs          # Internal Traefik container path for certs
+
+# Network Configurations
+# ==================
+PUBLICNET_GATEWAY=10.76.0.1                 # Gateway IP for publicnet Docker bridge
+PUBLICNET_SUBNET=10.76.0.0/16              # Subnet for publicnet Docker bridge
+PUBLICNET_IP_RANGE=10.76.0.0/16            # IP range for publicnet
+
+# VPS-Specific Configuration (only needed with docker-compose.traefik.vps.yml)
+# ===================
+GLUETUN_IPV4_ADDRESS=10.76.128.98          # Fixed internal IP for Gluetun VPN container

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+.history
 *.swp
+stremio-web-service-run.dev.sh
+stremio-web-service-run.original.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM node:18-alpine3.18 AS base
+FROM node:23-alpine AS base
 
 RUN apk update && apk upgrade
 
@@ -46,7 +46,7 @@ RUN cd && \
   PATH="$BIN:$PATH" && \
   ./configure --help && \
   ./configure --bindir="$BIN" --disable-debug \
-  --prefix=/usr/lib/jellyfin-ffmpeg --extra-version=Jellyfin --disable-doc --disable-ffplay --disable-shared --disable-libxcb --disable-sdl2 --disable-xlib --enable-lto --enable-gpl --enable-version3 --enable-gmp --enable-gnutls --enable-libdrm --enable-libass --enable-libfreetype --enable-libfribidi --enable-libfontconfig --enable-libbluray --enable-libmp3lame --enable-libopus --enable-libtheora --enable-libvorbis --enable-libdav1d --enable-libwebp --enable-libvpx --enable-libx264 --enable-libx265  --enable-libzimg --enable-small --enable-nonfree --enable-libxvid --enable-libaom --enable-libfdk_aac --enable-vaapi --enable-hwaccel=h264_vaapi --toolchain=hardened && \
+  --prefix=/usr/lib/jellyfin-ffmpeg --extra-version=Jellyfin --disable-doc --disable-ffplay --disable-shared --disable-libxcb --disable-sdl2 --disable-xlib --disable-asm --disable-x86asm --disable-inline-asm --disable-lto --enable-gpl --enable-version3 --enable-gmp --enable-gnutls --enable-libdrm --enable-libass --enable-libfreetype --enable-libfribidi --enable-libfontconfig --enable-libbluray --enable-libmp3lame --enable-libopus --enable-libtheora --enable-libvorbis --enable-libdav1d --enable-libwebp --enable-libvpx --enable-libx264 --enable-libx265  --enable-libzimg --enable-small --enable-nonfree --enable-libxvid --enable-libaom --enable-libfdk_aac --enable-vaapi --enable-hwaccel=h264_vaapi --extra-cflags="-O2 -fno-lto -fno-tree-vectorize" --extra-cxxflags="-O2 -fno-lto -fno-tree-vectorize" --extra-ldflags="-fno-lto" --toolchain=hardened && \
   make -j4 && \
   make install && \
   make distclean && \

--- a/docker-compose.traefik.vps.yml
+++ b/docker-compose.traefik.vps.yml
@@ -1,0 +1,245 @@
+# Deploy Stremio and the streaming server behind a VPN using Gluetun, and reverse proxied with Traefik.
+# This setup allows you to stream movies and TV shows from various sources while maintaining privacy and security.
+#
+# These environment variables are used to configure your containers for VPN, networking, Traefik, and service-specific behavior.
+# | Variable                     | Description                                                                                                                          |
+# | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+# | `ACME_RESOLVER_EMAIL`        | Email used specifically for the ACME certificate resolver within Traefik.
+# | `CERTS_PATH`                 | Local host path that stores TLS certificates for Traefik. Mounted into the container.                                                |
+# | `CONFIG_PATH`                | Root path for configuration volume mounts (default: `./configs`).                                                                    |
+# | `CONFIGS_PATH`               | Local host path for Traefik configuration files (default: `./configs`).                                                              |
+# | `DOMAIN`                     | Your root domain (e.g., `example.com`). Used for setting up subdomain-based routing via Traefik.                                     |
+# | `DUCKDNS_TOKEN`              | API token for the DuckDNS DNS challenge provider. Required for wildcard cert generation.                                             |
+# | `GLUETUN_IPV4_ADDRESS`       | The fixed internal IP for the Gluetun container (default: `10.76.128.98`). Required for consistent DNS resolution across containers. |
+# | `LETS_ENCRYPT_EMAIL`         | Email address used for Let's Encrypt certificate registration.                                                                       |
+# | `PUBLICNET_GATEWAY`          | Gateway IP for the `publicnet` Docker bridge (default: `10.76.0.1`).                                                                 |
+# | `PUBLICNET_IP_RANGE`         | IP range available for assignment in `publicnet` (default: `10.76.0.0/16`).                                                          |
+# | `PUBLICNET_SUBNET`           | Subnet used by the custom Docker bridge network `publicnet` (default: `10.76.0.0/16`).                                               |
+# | `SRC_PATH`                   | Path to source directory for the Stremio Docker build (default: `./src`).                                                            |
+# | `TRAEFIK_INTERNAL_CERTS_DIR` | Internal path inside the Traefik container where TLS certificates and ACME storage are stored (default: `/certs`).                   |
+#
+# Other environment variables (used in the stremio-web-service-run.sh script):
+# | `APP_PATH`                   | Optional. Sets custom configuration folder path. Default: $HOME/.stremio-server/
+# | `CERT_FILE`:                 | Optional. Custom certificate file name (used with DOMAIN)
+# | `DOMAIN`:                    | Optional. Custom domain name for certificate (used with CERT_FILE)
+# | `IPADDRESS`:                 | Optional. IP address for HTTPS certificate generation
+# | `SERVER_URL`:                | Optional. Custom server URL. Supports IP address, domain name, or 0.0.0.0
+# | `UPDATE_HOSTS`:              | Optional. Set to "true" to update /etc/hosts with certificate domain
+
+
+services:
+  stremio:
+    # 🔹🔹 Stremio 🔹🔹
+    # Stream Movies/TV over debrid instantly.
+    depends_on:
+      gluetun:
+        condition: service_healthy
+    build:
+      context: ${SRC_PATH:-./src}/stremio/stremio-docker
+      dockerfile: Dockerfile
+    image: th3w1zard1/stremio-docker:latest
+    container_name: stremio
+    network_mode: service:gluetun
+    volumes:
+      - ${CONFIG_PATH:-./configs}/stremio/root/.stremio-server:/root/.stremio-server
+    environment:
+      # Note: You CANNOT use the autodetection '0.0.0.0' unless traefik is *also* routed through the VPN.
+      IPADDRESS: 127.0.0.1  # Set to your public/LAN IP address.
+#     SERVER_URL: "https://0-0-0-0.519b6502d940.stremio.rocks:12470/"
+      # Force a streaming server URL in the 'streaming' tab of the web UI.
+      # Note: Anytime this is changed on the frontend by the user, the page will redirect automatically and reset to this URL.
+      # This prevents the user from changing it.
+      SERVER_URL: "https://stremio.${DOMAIN}"
+      # Where the streaming server will redirect to.
+      # Defaults to "https://app.strem.io/shell-v4.4/"
+      WEBUI_LOCATION: "https://stremio-web.${DOMAIN}/shell/"
+      NO_CORS: 0
+      # Disable chromecast support if you don't plan on using this container across your LAN.
+      # This is a workaround for the "No devices found" error in the web UI.
+      CASTING_DISABLED: 1
+    labels:
+      traefik.enable: "true"
+      # Stremio Web
+      traefik.http.routers.stremio-web.service: stremio-web
+      traefik.http.routers.stremio-web.rule: Host(`stremio-web.${DOMAIN}`)
+      traefik.http.services.stremio-web.loadbalancer.server.scheme: https
+      traefik.http.services.stremio-web.loadbalancer.server.port: 8080
+      # Stremio HTTPS Streaming Server
+      traefik.http.routers.stremio.service: stremio
+      traefik.http.routers.stremio.rule: Host(`stremio.${DOMAIN}`)
+      traefik.http.services.stremio.loadbalancer.server.scheme: https
+      traefik.http.services.stremio.loadbalancer.server.port: 12470
+      # Stremio HTTP Streaming Server
+      # NOTE: in my experience the 11470 never works correctly. Has various issues I could never debug.
+      # I recommend using the HTTPS streaming server instead (12470, above).
+      traefik.http.routers.stremio-fallback.service: stremio-fallback
+      traefik.http.routers.stremio-fallback.rule: Host(`stremio.${DOMAIN}`)
+      traefik.http.services.stremio-fallback.loadbalancer.server.scheme: http
+      traefik.http.services.stremio-fallback.loadbalancer.server.port: 11470
+      homepage.group: Media Streaming
+      homepage.name: Stremio
+      homepage.icon: stremio.png
+      homepage.href: https://stremio.${DOMAIN}/
+      homepage.description: A one-stop hub for video content aggregation, allowing you to stream movies, series, and more from various sources.
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fs http://127.0.0.1:11470 || curl -fs http://127.0.0.1:12470"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    restart: always
+
+  gluetun:  # United States
+    # 🔹🔹 Gluetun 🔹🔹  # https://github.com/qdm12/gluetun
+    # Gluetun is a VPN client that supports various VPN protocols, providing secure and private internet access for your applications.
+    image: ghcr.io/qdm12/gluetun
+    container_name: gluetun
+    hostname: gluetun
+    networks:
+      publicnet:
+        ipv4_address: ${GLUETUN_IPV4_ADDRESS:-10.76.128.98}
+    cap_add:
+      - NET_ADMIN
+    sysctls:
+      net.ipv6.conf.all.disable_ipv6: 1
+    extra_hosts:
+      - host.docker.internal:172.17.0.1
+      - gluetun:${GLUETUN_IPV4_ADDRESS:-10.76.128.98}
+      - vpn-us.premiumize.me:199.58.86.204
+    expose:  # unnecessary, but helps for things like `docker inspect` and portainer.
+      - 8080  # Stremio
+      - 11470 # Stremio HTTP Streaming Server
+      - 12470 # Stremio HTTPS Streaming Server
+    devices:
+      - "/dev/net/tun:/dev/net/tun" # https://github.com/qdm12/gluetun-wiki/blob/main/errors/tun.md
+    volumes:
+      - ${CONFIG_PATH:-./configs}/gluetun/premiumize/config:/gluetun
+      - ${CONFIG_PATH:-./configs}/gluetun/premiumize/us/etc/openvpn:/etc/openvpn
+    ports:
+      - "8080:8080"  # Web UI (feel free to remove this line since we are using Traefik)
+      # The following ports are used for the streaming server.
+      - "12470:12470"  # HTTPS Streaming Server (recommended)
+      - "11470:11470"  # HTTP Streaming Server (fallback)
+    environment:
+      - VPN_SERVICE_PROVIDER=custom
+      - OPENVPN_CUSTOM_CONFIG=/gluetun/vpn-us.premiumize.me.ovpn
+      - OPENVPN_CIPHERS=AES-256-CBC
+      - OPENVPN_FLAGS=--auth-user-pass /etc/openvpn/auth.conf
+      - BLOCK_ADS=on  # Uses ads hostnames and IP addresses block lists for Unbound: https://github.com/qdm12/files
+      - BLOCK_MALICIOUS=on  # Uses malicious hostnames and IP addresses block lists for Unbound: https://github.com/qdm12/files
+      - BLOCK_SURVEILLANCE=on  # Uses surveillance hostnames and IP addresses block lists for Unbound: https://github.com/qdm12/files
+      - DOT_IPV6=off
+      # firewall references:
+      # https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/firewall.md
+      # https://github.com/qdm12/gluetun-wiki/blob/main/errors/firewall.md
+      # https://github.com/qdm12/gluetun-wiki/blob/main/errors/routing.md
+      # Comma separated subnets that Gluetun and the containers sharing its network stack are allowed to access. This involves firewall and routing modifications.
+      - FIREWALL_OUTBOUND_SUBNETS=10.76.0.0/16,172.17.0.0/16,100.64.0.0/10  # publicnet,docker0,tailscale. feel free to remove the tailscale subnet if you don't use it.
+      - OPENVPN_IPV6=off
+      - OPENVPN_PROTOCOL=tcp
+      - OPENVPN_ROOT=no
+      - OPENVPN_VERSION=2.6
+      - STORAGE_FILEPATH=/gluetun/servers/servers.json
+      - VERSION_INFORMATION=on
+      - VPN_TYPE=openvpn
+    labels:
+      traefik.enable: "true"
+      # Stremio Web
+      traefik.http.routers.stremio-web.service: stremio-web
+      traefik.http.routers.stremio-web.rule: Host(`stremio-web.${DOMAIN}`)
+      traefik.http.services.stremio-web.loadbalancer.server.scheme: https
+      traefik.http.services.stremio-web.loadbalancer.server.port: 8080
+      # Stremio HTTPS Streaming Server
+      traefik.http.routers.stremio.service: stremio
+      traefik.http.routers.stremio.rule: Host(`stremio.${DOMAIN}`)
+      traefik.http.services.stremio.loadbalancer.server.scheme: https
+      traefik.http.services.stremio.loadbalancer.server.port: 12470
+      # Stremio HTTP Streaming Server
+      # NOTE: in my experience the 11470 never works correctly. Has various issues I could never debug.
+      # I recommend using the HTTPS streaming server instead (12470, configured above).
+      traefik.http.routers.stremio-fallback.service: stremio-fallback
+      traefik.http.routers.stremio-fallback.rule: Host(`stremio.${DOMAIN}`)
+      traefik.http.services.stremio-fallback.loadbalancer.server.scheme: http
+      traefik.http.services.stremio-fallback.loadbalancer.server.port: 11470
+    restart: always
+
+  # Multiple DNS challenge provider are not supported with Traefik,
+  # but you can use CNAME to handle that. For example, if you have example.org (account foo) and
+  # example.com (account bar) you can create a CNAME on example.org called _acme-challenge.example.org
+  # pointing to challenge.example.com. This way, you can obtain certificates for example.org with the bar account.
+  traefik:
+    # 🔹🔹 Traefik 🔹🔹
+    image: traefik
+    container_name: traefik
+    hostname: traefik
+    extra_hosts:
+      - host.docker.internal:172.17.0.1
+    networks:
+      - auth-net
+      - traefik_public
+    ports:
+      # Listen on port 80, default for HTTP, necessary to redirect to HTTPS
+      - 80:80
+      # Listen on port 443, default for HTTPS
+      - 443:443
+    cap_add:
+      - NET_ADMIN
+    sysctls:
+      net.ipv6.conf.all.disable_ipv6: 1
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${CONFIGS_PATH:-./configs}/traefik/config:/config
+      - ${CERTS_PATH:-./certs}:${TRAEFIK_INTERNAL_CERTS_DIR:-/certs}
+    #      - /etc/localtime:/etc/localtime:ro
+    # Note: The environment variable names can be suffixed by _FILE to reference a file instead of a value
+    environment:
+      <<: *common-env
+      DUCKDNS_TOKEN: ${DUCKDNS_TOKEN:?not set} # DuckDNS token (required for DuckDNS provider)
+      LETS_ENCRYPT_EMAIL: ${LETS_ENCRYPT_EMAIL} # Email address used for Letsencrypt registration.
+    command:
+      - --accesslog=true # Enable the access log, with HTTP requests
+      - --certificatesresolvers.myresolver.acme.caServer=https://acme-v02.api.letsencrypt.org/directory  # Let's Encrypt has a limit: 5 certs generated a week. Use staging when breaking things (specifically https://acme-staging-v02.api.letsencrypt.org/directory). see https://doc.traefik.io/traefik/https/acme/#caserver
+      - --certificatesresolvers.myresolver.acme.dnsChallenge.provider=duckdns
+      - --certificatesresolvers.myresolver.acme.dnsChallenge=true # Use the DNS challenges from 'duckdns'. (Default: false)
+      - --certificatesresolvers.myresolver.acme.email=${ACME_RESOLVER_EMAIL} # Email address used for ACME registration.
+      - --certificatesresolvers.myresolver.acme.httpChallenge.entryPoint=web
+      - --certificatesresolvers.myresolver.acme.httpChallenge=true # Activate HTTP-01 Challenge. (Default: false)
+      - --certificatesresolvers.myresolver.acme.tlsChallenge=true # Use the TLS-ALPN-01 challenge to generate and renew ACME certificates by provisioning a TLS certificate.  As described on the Let's Encrypt community forum, when using the TLS-ALPN-01 challenge, Traefik must be reachable by Let's Encrypt through port 443.
+      - --certificatesresolvers.myresolver.acme.storage=${TRAEFIK_INTERNAL_CERTS_DIR:-/certs}/acme.json # Storage to use. (Default: acme.json)
+      - --entrypoints.web.address=:80
+      - --entrypoints.web.asDefault=false # Adds this EntryPoint to the list of default EntryPoints to be used on routers that don't have any Entrypoint defined. (Default: false)
+      - --entrypoints.web.http.redirections.entryPoint.scheme=https # The redirection target scheme (optional).
+      - --entrypoints.web.http.redirections.entryPoint.permanent=true # The redirection is permanent (301) or temporary (302).
+      - --entrypoints.web.http.redirections.entryPoint.to=websecure # The redirection target entry point.
+      - --entrypoints.web.observability.accesslogs=true
+      - --entrypoints.web.observability.metrics=true
+      - --entrypoints.web.observability.tracing=true
+      - --entrypoints.websecure.address=:443
+      - --entrypoints.websecure.asDefault=true # Adds this EntryPoint to the list of default EntryPoints to be used on routers that don't have any Entrypoint defined. (Default: false)
+      - --entrypoints.websecure.observability.accesslogs=true
+      - --entrypoints.websecure.observability.metrics=true
+      - --entrypoints.websecure.observability.tracing=true
+      - --entrypoints.websecure.http.tls.certResolver=myresolver
+      - --entrypoints.websecure.http.tls.domains[0].main=${DOMAIN}
+      - --entrypoints.websecure.http.tls.domains[0].sans=*.${DOMAIN}  # Remove this line to disable wildcard certs (new certificate for every subdomain).
+      - --entrypoints.websecure.http.tls=true
+      - --log # Enable the Traefik log, for configurations and errors
+      - --log.level=INFO # Log level. (Default: INFO)
+      - --providers.docker.defaultRule=Host(`{{ .ContainerName }}.${DOMAIN}`) # Default rule.
+      - --providers.docker.endpoint=unix:///var/run/docker.sock # Docker server endpoint. Can be a TCP or a Unix socket endpoint. (Default: unix:///var/run/docker.sock)
+      - --providers.docker.exposedByDefault=false  # Expose all containers by default. (Default: true)
+      - --providers.docker.network=publicnet # Default Docker network used.
+      - --providers.docker=true # Enable Docker in Traefik, so that it reads labels from Docker services and containers.
+    restart: always
+
+networks:
+  publicnet:  # https://docs.docker.com/engine/network/drivers/bridge/#differences-between-user-defined-bridges-and-the-default-bridge
+# Uncomment the following line to use an external network created in the cli, instead of creating a new one per stack.
+#    external: true  # docker network create --driver=bridge --attachable publicnet --subnet=${PUBLICNET_SUBNET:-10.76.0.0/16} --gateway=${PUBLICNET_GATEWAY:-10.76.0.1} --ip-range=${PUBLICNET_IP_RANGE:-10.76.0.0/16}
+    attachable: true  # allow containers outside of this docker-compose.yml stack file to access this network.
+    name: publicnet
+    ipam:
+      config:
+        - subnet: ${PUBLICNET_SUBNET:-10.76.0.0/16}
+          gateway: ${PUBLICNET_GATEWAY:-10.76.0.1}
+          ip_range: ${PUBLICNET_IP_RANGE:-10.76.0.0/16}

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -1,0 +1,171 @@
+# Deploy Stremio and the streaming server behind a VPN using Gluetun, and reverse proxied with Traefik.
+# This setup allows you to stream movies and TV shows from various sources while maintaining privacy and security.
+#
+# These environment variables are used to configure your containers for stremio and Traefik.
+# | Variable                     | Description                                                                                                                          |
+# | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+# | `ACME_RESOLVER_EMAIL`        | Email used specifically for the ACME certificate resolver within Traefik.
+# | `CERTS_PATH`                 | Local host path that stores TLS certificates for Traefik. Mounted into the container.                                                |
+# | `CONFIG_PATH`                | Root path for configuration volume mounts (default: `./configs`).                                                                    |
+# | `CONFIGS_PATH`               | Local host path for Traefik configuration files (default: `./configs`).                                                              |
+# | `DOMAIN`                     | Your root domain (e.g., `example.com`). Used for setting up subdomain-based routing via Traefik.                                     |
+# | `DUCKDNS_TOKEN`              | API token for the DuckDNS DNS challenge provider. Required for wildcard cert generation.                                             |
+# | `LETS_ENCRYPT_EMAIL`         | Email address used for Let's Encrypt certificate registration.                                                                       |
+# | `PUBLICNET_GATEWAY`          | Gateway IP for the `publicnet` Docker bridge (default: `10.76.0.1`).                                                                 |
+# | `PUBLICNET_IP_RANGE`         | IP range available for assignment in `publicnet` (default: `10.76.0.0/16`).                                                          |
+# | `PUBLICNET_SUBNET`           | Subnet used by the custom Docker bridge network `publicnet` (default: `10.76.0.0/16`).                                               |
+# | `SRC_PATH`                   | Path to source directory for the Stremio Docker build (default: `./src`).                                                            |
+# | `TRAEFIK_INTERNAL_CERTS_DIR` | Internal path inside the Traefik container where TLS certificates and ACME storage are stored (default: `/certs`).                   |
+#
+# Other environment variables (used in the stremio-web-service-run.sh script):
+# | `APP_PATH`                   | Optional. Sets custom configuration folder path. Default: $HOME/.stremio-server/
+# | `CERT_FILE`:                 | Optional. Custom certificate file name (used with DOMAIN)
+# | `DOMAIN`:                    | Optional. Custom domain name for certificate (used with CERT_FILE)
+# | `IPADDRESS`:                 | Optional. IP address for HTTPS certificate generation
+# | `SERVER_URL`:                | Optional. Custom server URL. Supports IP address, domain name, or 0.0.0.0
+# | `UPDATE_HOSTS`:              | Optional. Set to "true" to update /etc/hosts with certificate domain
+
+services:
+  stremio:
+    # 🔹🔹 Stremio 🔹🔹
+    # Stream Movies/TV instantly from a large collection of sources.
+    # https://stremio.com
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: th3w1zard1/stremio-docker:latest
+    container_name: stremio
+    hostname: stremio
+    networks:
+      - publicnet
+    ports:
+      - "8080:8080"  # Web UI (feel free to remove this line since we are using Traefik)
+      # The following ports are used for the streaming server.
+      - "12470:12470"  # HTTPS Streaming Server (recommended)
+      - "11470:11470"  # HTTP Streaming Server (fallback)
+    volumes:
+      - ${CONFIG_PATH:-./configs}/stremio/root/.stremio-server:/root/.stremio-server
+    <<: [*common-logging, *resource-limits]
+    environment:
+      # 0.0.0.0 will auto-resolve to your public IP.
+      # Alternatively, you can set your public/LAN IP address here.
+      IPADDRESS: 0.0.0.0
+      # Force a streaming server URL in the 'streaming' tab of the web UI.
+      # Note: Anytime this is changed on the frontend by the user, the page will redirect automatically and reset to this URL.
+      # This prevents the user from changing it.
+      SERVER_URL: "https://stremio.${DOMAIN}"
+      # Alternatively, use stremio's own ngrok-style server URL.
+      # The 0-0-0-0 will auto-resolve to your public IP.
+#      SERVER_URL: "https://0-0-0-0.519b6502d940.stremio.rocks:12470/"
+      WEBUI_LOCATION: "https://stremio-web.${DOMAIN}/shell/"  # Where the streaming server will redirect to. Defaults to "https://app.strem.io/shell-v4.4/"
+      NO_CORS: 0
+      # Disable chromecast support if you don't plan on using this container across your LAN.
+      # This is a workaround for the "No devices found" error in the web UI.
+      CASTING_DISABLED: 1
+    labels:
+      traefik.enable: "true"
+      # Stremio Web
+      traefik.http.routers.stremio-web.service: stremio-web
+      traefik.http.routers.stremio-web.rule: Host(`stremio-web.${DOMAIN}`)
+      traefik.http.services.stremio-web.loadbalancer.server.scheme: https
+      traefik.http.services.stremio-web.loadbalancer.server.port: 8080
+      # Stremio HTTPS Streaming Server
+      traefik.http.routers.stremio.service: stremio
+      traefik.http.routers.stremio.rule: Host(`stremio.${DOMAIN}`)
+      traefik.http.services.stremio.loadbalancer.server.scheme: https
+      traefik.http.services.stremio.loadbalancer.server.port: 12470
+      # Stremio HTTP Streaming Server
+      # NOTE: in my experience the 11470 never works correctly. Has various issues I could never debug.
+      # I recommend using the HTTPS streaming server instead (12470, configured above).
+      traefik.http.routers.stremio-fallback.service: stremio-fallback
+      traefik.http.routers.stremio-fallback.rule: Host(`stremio.${DOMAIN}`)
+      traefik.http.services.stremio-fallback.loadbalancer.server.scheme: http
+      traefik.http.services.stremio-fallback.loadbalancer.server.port: 11470
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fs http://127.0.0.1:11470 || curl -fs http://127.0.0.1:12470"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    restart: always
+
+  # Multiple DNS challenge provider are not supported with Traefik,
+  # but you can use CNAME to handle that. For example, if you have example.org (account foo) and
+  # example.com (account bar) you can create a CNAME on example.org called _acme-challenge.example.org
+  # pointing to challenge.example.com. This way, you can obtain certificates for example.org with the bar account.
+  traefik:
+    # 🔹🔹 Traefik 🔹🔹
+    image: traefik
+    container_name: traefik
+    hostname: traefik
+    extra_hosts:
+      - host.docker.internal:172.17.0.1
+    networks:
+      - auth-net
+      - traefik_public
+    ports:
+      # Listen on port 80, default for HTTP, necessary to redirect to HTTPS
+      - 80:80
+      # Listen on port 443, default for HTTPS
+      - 443:443
+    cap_add:
+      - NET_ADMIN
+    sysctls:
+      net.ipv6.conf.all.disable_ipv6: 1
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${CONFIGS_PATH:-./configs}/traefik/config:/config
+      - ${CERTS_PATH:-./certs}:${TRAEFIK_INTERNAL_CERTS_DIR:-/certs}
+    #      - /etc/localtime:/etc/localtime:ro
+    # Note: The environment variable names can be suffixed by _FILE to reference a file instead of a value
+    environment:
+      <<: *common-env
+      DUCKDNS_TOKEN: ${DUCKDNS_TOKEN:?not set} # DuckDNS token (required for DuckDNS provider)
+      LETS_ENCRYPT_EMAIL: ${LETS_ENCRYPT_EMAIL} # Email address used for Letsencrypt registration.
+    command:
+      - --accesslog=true # Enable the access log, with HTTP requests
+      - --certificatesresolvers.myresolver.acme.caServer=https://acme-v02.api.letsencrypt.org/directory  # Let's Encrypt has a limit: 5 certs generated a week. Use staging when breaking things (specifically https://acme-staging-v02.api.letsencrypt.org/directory). see https://doc.traefik.io/traefik/https/acme/#caserver
+      - --certificatesresolvers.myresolver.acme.dnsChallenge.provider=duckdns
+      - --certificatesresolvers.myresolver.acme.dnsChallenge=true # Use the DNS challenges from 'duckdns'. (Default: false)
+      - --certificatesresolvers.myresolver.acme.email=${ACME_RESOLVER_EMAIL} # Email address used for ACME registration.
+      - --certificatesresolvers.myresolver.acme.httpChallenge.entryPoint=web
+      - --certificatesresolvers.myresolver.acme.httpChallenge=true # Activate HTTP-01 Challenge. (Default: false)
+      - --certificatesresolvers.myresolver.acme.tlsChallenge=true # Use the TLS-ALPN-01 challenge to generate and renew ACME certificates by provisioning a TLS certificate.  As described on the Let's Encrypt community forum, when using the TLS-ALPN-01 challenge, Traefik must be reachable by Let's Encrypt through port 443.
+      - --certificatesresolvers.myresolver.acme.storage=${TRAEFIK_INTERNAL_CERTS_DIR:-/certs}/acme.json # Storage to use. (Default: acme.json)
+      - --entrypoints.web.address=:80
+      - --entrypoints.web.asDefault=false # Adds this EntryPoint to the list of default EntryPoints to be used on routers that don't have any Entrypoint defined. (Default: false)
+      - --entrypoints.web.http.redirections.entryPoint.scheme=https # The redirection target scheme (optional).
+      - --entrypoints.web.http.redirections.entryPoint.permanent=true # The redirection is permanent (301) or temporary (302).
+      - --entrypoints.web.http.redirections.entryPoint.to=websecure # The redirection target entry point.
+      - --entrypoints.web.observability.accesslogs=true
+      - --entrypoints.web.observability.metrics=true
+      - --entrypoints.web.observability.tracing=true
+      - --entrypoints.websecure.address=:443
+      - --entrypoints.websecure.asDefault=true # Adds this EntryPoint to the list of default EntryPoints to be used on routers that don't have any Entrypoint defined. (Default: false)
+      - --entrypoints.websecure.observability.accesslogs=true
+      - --entrypoints.websecure.observability.metrics=true
+      - --entrypoints.websecure.observability.tracing=true
+      - --entrypoints.websecure.http.tls.certResolver=myresolver
+      - --entrypoints.websecure.http.tls.domains[0].main=${DOMAIN}
+      - --entrypoints.websecure.http.tls.domains[0].sans=*.${DOMAIN}  # Remove this line to disable wildcard certs (new certificate for every subdomain).
+      - --entrypoints.websecure.http.tls=true
+      - --log # Enable the Traefik log, for configurations and errors
+      - --log.level=INFO # Log level. (Default: INFO)
+      - --providers.docker.defaultRule=Host(`{{ .ContainerName }}.${DOMAIN}`) # Default rule.
+      - --providers.docker.endpoint=unix:///var/run/docker.sock # Docker server endpoint. Can be a TCP or a Unix socket endpoint. (Default: unix:///var/run/docker.sock)
+      - --providers.docker.exposedByDefault=false  # Expose all containers by default. (Default: true)
+      - --providers.docker.network=publicnet # Default Docker network used.
+      - --providers.docker=true # Enable Docker in Traefik, so that it reads labels from Docker services and containers.
+    restart: always
+
+networks:
+  publicnet:  # https://docs.docker.com/engine/network/drivers/bridge/#differences-between-user-defined-bridges-and-the-default-bridge
+# Uncomment the following line to use an external network created in the cli, instead of creating a new one per stack.
+#    external: true  # docker network create --driver=bridge --attachable publicnet --subnet=${PUBLICNET_SUBNET:-10.76.0.0/16} --gateway=${PUBLICNET_GATEWAY:-10.76.0.1} --ip-range=${PUBLICNET_IP_RANGE:-10.76.0.0/16}
+    attachable: true  # allow containers outside of this docker-compose.yml stack file to access this network.
+    name: publicnet
+    ipam:
+      config:
+        - subnet: ${PUBLICNET_SUBNET:-10.76.0.0/16}
+          gateway: ${PUBLICNET_GATEWAY:-10.76.0.1}
+          ip_range: ${PUBLICNET_IP_RANGE:-10.76.0.0/16}

--- a/stremio-web-service-run.sh
+++ b/stremio-web-service-run.sh
@@ -1,52 +1,276 @@
 #!/bin/sh -e
 
-# set the configuration folder path.
+#############################################
+# STREMIO WEB SERVICE RUN SCRIPT
+#############################################
+# This script manages the Stremio web service, handling configuration setup,
+# server patching, IP resolution, and certificate management for both HTTP and HTTPS.
+# It supports automatic public IP detection, domain resolution, and HTTPS certificate generation.
+#
+# Environment variables:
+# - APP_PATH:      Optional. Sets custom configuration folder path. Default: $HOME/.stremio-server/
+# - SERVER_URL:    Optional. Custom server URL. Supports IP address, domain name, or 0.0.0.0
+# - IPADDRESS:     Optional. IP address for HTTPS certificate generation
+# - UPDATE_HOSTS:  Optional. Set to "true" to update /etc/hosts with certificate domain
+# - CERT_FILE:     Optional. Custom certificate file name (used with DOMAIN)
+# - DOMAIN:        Optional. Custom domain name for certificate (used with CERT_FILE)
+
+#############################################
+# INITIAL SERVER CONFIGURATION
+#############################################
+
+# Set the configuration folder path.
 CONFIG_FOLDER="${APP_PATH:-${HOME}/.stremio-server/}"
 
-# check if proxyStreamsEnabled is set to false in server.js and add it if not.
-if ! grep -q 'self.proxyStreamsEnabled = false,' server.js; then
-    sed -i '/self.allTranscodeProfiles = \[\]/a \ \ \ \ \ \ \ \ self.proxyStreamsEnabled = false,' server.js
+# Update paths in server-settings.json if it exists
+if [ -f "${CONFIG_FOLDER}server-settings.json" ]; then
+    echo "[CONFIG] Found server-settings.json at ${CONFIG_FOLDER}server-settings.json"
+    # Remove trailing slash from CONFIG_FOLDER for consistency in the JSON file
+    CONFIG_PATH=$(echo "${CONFIG_FOLDER}" | sed 's:/$::')
+
+    # Get current values for logging
+    CURRENT_APP_PATH=$(grep -o '"appPath": "[^"]*"' "${CONFIG_FOLDER}server-settings.json" | cut -d'"' -f4)
+    CURRENT_CACHE_ROOT=$(grep -o '"cacheRoot": "[^"]*"' "${CONFIG_FOLDER}server-settings.json" | cut -d'"' -f4)
+
+    echo "[CONFIG] Updating paths in server-settings.json:"
+    echo "  - appPath: '${CURRENT_APP_PATH}' -> '${CONFIG_PATH}'"
+    echo "  - cacheRoot: '${CURRENT_CACHE_ROOT}' -> '${CONFIG_PATH}'"
+
+    sed -i "s|\"appPath\": \"[^\"]*\"|\"appPath\": \"${CONFIG_PATH}\"|g" "${CONFIG_FOLDER}server-settings.json"
+    sed -i "s|\"cacheRoot\": \"[^\"]*\"|\"cacheRoot\": \"${CONFIG_PATH}\"|g" "${CONFIG_FOLDER}server-settings.json"
 fi
 
-sed -i 's/df -k/df -Pk/g' server.js
+#############################################
+# HELPER FUNCTIONS
+#############################################
+
+# Function to start HTTP server with specified options
+start_http_server() {
+    echo "[SERVER] Starting HTTP server on port 8080 with options: $*"
+    http-server build/ -p 8080 -d false "$@"
+}
+
+# Function to get public IP address from various services
+get_public_ip() {
+    # Try multiple services to get public IP in case one fails
+    PUBLIC_IP=""
+
+    # Try ifconfig.me first
+    if [ -z "${PUBLIC_IP}" ]; then
+        echo "[IP LOOKUP] Attempting to get public IP from ifconfig.me..." >&2
+        IP_RESULT=$(curl -s --connect-timeout 5 https://ifconfig.me)
+        if [ -n "${IP_RESULT}" ] && [ "${IP_RESULT}" != "curl: "* ]; then
+            echo "[IP LOOKUP] Successfully obtained IP from ifconfig.me: ${IP_RESULT}" >&2
+            PUBLIC_IP="${IP_RESULT}"
+        else
+            echo "[IP LOOKUP] Failed to get IP from ifconfig.me" >&2
+        fi
+    fi
+
+    # If ifconfig.me failed, try icanhazip
+    if [ -z "${PUBLIC_IP}" ]; then
+        echo "[IP LOOKUP] Attempting to get public IP from icanhazip.com..." >&2
+        IP_RESULT=$(curl -s --connect-timeout 5 https://icanhazip.com)
+        if [ -n "${IP_RESULT}" ] && [ "${IP_RESULT}" != "curl: "* ]; then
+            echo "[IP LOOKUP] Successfully obtained IP from icanhazip.com: ${IP_RESULT}" >&2
+            PUBLIC_IP="${IP_RESULT}"
+        else
+            echo "[IP LOOKUP] Failed to get IP from icanhazip.com" >&2
+        fi
+    fi
+
+    # Return only the IP address, no debug messages
+    echo "${PUBLIC_IP}"
+}
+
+# Patch server.js with necessary fixes
+echo "[PATCH] Checking server.js for required patches..."
+
+# Disable proxy streams if not already disabled
+if ! grep -q 'self.proxyStreamsEnabled = false,' server.js; then
+    echo "[PATCH] Adding 'self.proxyStreamsEnabled = false' to server.js after 'self.allTranscodeProfiles = []' line"
+    sed -i '/self.allTranscodeProfiles = \[\]/a \ \ \ \ \ \ \ \ self.proxyStreamsEnabled = false,' server.js
+    echo "[PATCH] ✓ Proxy streams disabled"
+else
+    echo "[PATCH] ✓ Proxy streams already disabled"
+fi
+
+# Fix disk space check to work in all environments
+if grep -q 'df -k' server.js; then
+    echo "[PATCH] Replacing 'df -k' with 'df -Pk' in server.js to ensure consistent output format across systems"
+    sed -i 's/df -k/df -Pk/g' server.js
+    echo "[PATCH] ✓ Disk space check fixed"
+else
+    echo "[PATCH] ✓ Disk space check already using correct command"
+fi
+
+#############################################
+# SERVER URL CONFIGURATION
+#############################################
 
 if [ -n "${SERVER_URL}" ]; then
+    echo "[URL CONFIG] Processing SERVER_URL: ${SERVER_URL}"
+    ORIGINAL_SERVER_URL="${SERVER_URL}"
+
+    # Handle special cases in SERVER_URL (0.0.0.0 or stremio.rocks domains)
+    if echo "${SERVER_URL}" | grep -q "0\.0\.0\.0"; then
+        echo "[URL CONFIG] Found '0.0.0.0' in SERVER_URL, will replace with actual IP"
+        PUBLIC_IP=$(get_public_ip)
+
+        if [ -n "${PUBLIC_IP}" ]; then
+            # Replace 0.0.0.0 with the public IP while preserving protocol and port
+            SERVER_URL=$(echo "${SERVER_URL}" | sed "s/0\.0\.0\.0/${PUBLIC_IP}/g")
+            echo "[URL CONFIG] Replaced 0.0.0.0 with public IP: ${ORIGINAL_SERVER_URL} -> ${SERVER_URL}"
+        else
+            echo "[URL CONFIG] Failed to obtain public IP, keeping original SERVER_URL with 0.0.0.0"
+        fi
+    elif echo "${SERVER_URL}" | grep -q "0-0-0-0\.519b6502d940\.stremio\.rocks"; then
+        echo "[URL CONFIG] Found 'stremio.rocks' test domain in SERVER_URL, will replace with actual IP"
+        PUBLIC_IP=$(get_public_ip)
+
+        if [ -n "${PUBLIC_IP}" ]; then
+            # Replace 0-0-0-0.519b6502d940.stremio.rocks with the public IP
+            SERVER_URL=$(echo "${SERVER_URL}" | sed "s/0-0-0-0\.519b6502d940\.stremio\.rocks/${PUBLIC_IP}/g")
+            echo "[URL CONFIG] Replaced stremio.rocks domain with public IP: ${ORIGINAL_SERVER_URL} -> ${SERVER_URL}"
+        else
+            echo "[URL CONFIG] Failed to obtain public IP, keeping original SERVER_URL with stremio.rocks domain"
+        fi
+    else
+        # Handle domains that need IP resolution
+        SERVER_DOMAIN=$(echo "${SERVER_URL}" | sed -E 's|^(https?://)([^:/]+).*|\2|')
+        if [ -n "${SERVER_DOMAIN}" ] && [ "${SERVER_DOMAIN}" != "${SERVER_URL}" ]; then
+            echo "[URL CONFIG] Checking if domain in SERVER_URL can be resolved: ${SERVER_DOMAIN}"
+            RESOLVED_IP=$(resolve_domain_to_ip "${SERVER_DOMAIN}")
+
+            if [ "${RESOLVED_IP}" != "${SERVER_DOMAIN}" ]; then
+                # Only update if we actually got an IP different from the domain
+                SERVER_URL=$(echo "${SERVER_URL}" | sed "s/${SERVER_DOMAIN}/${RESOLVED_IP}/g")
+                echo "[URL CONFIG] Replaced domain with resolved IP: ${ORIGINAL_SERVER_URL} -> ${SERVER_URL}"
+            else
+                echo "[URL CONFIG] Domain could not be resolved to IP, keeping original SERVER_URL"
+            fi
+        fi
+    fi
+
+    # Ensure URL has trailing slash for consistency
+    SERVER_URL_BEFORE="${SERVER_URL}"
+    SERVER_URL=$(echo "${SERVER_URL}" | sed 's:/*$:/:')
+
+    if [ "${SERVER_URL}" != "${SERVER_URL_BEFORE}" ]; then
+        echo "[URL CONFIG] Added trailing slash for consistency: ${SERVER_URL_BEFORE} -> ${SERVER_URL}"
+    fi
+
+    echo "[URL CONFIG] Final server URL: ${SERVER_URL}"
+
+    # Update localStorage for the web client to use our server
+    echo "[CONFIG] Updating localStorage.json to use configured server URL"
+    echo "[CONFIG] Replacing 'http://127.0.0.1:11470/' with '${SERVER_URL}'"
     cp localStorage.json build/localStorage.json
     sed -i "s|http://127.0.0.1:11470/|${SERVER_URL}|g" build/localStorage.json
 fi
 
-start_http_server() {
-    http-server build/ -p 8080 -d false "$@"
-}
+#############################################
+# WEB UI CONFIGURATION
+#############################################
 
-if [ -n "${IPADDRESS}" ]; then 
+# Echo startup message
+echo "[STARTUP] Starting Stremio server at $(date)"
+echo "[STARTUP] Configuration summary:"
+echo "  - Config folder: ${CONFIG_FOLDER}"
+echo "  - IP Address: ${IPADDRESS}"
+echo "  - Server URL: ${SERVER_URL}"
+
+# Handle different startup modes based on configuration
+if [ -n "${IPADDRESS}" ]; then
+    # Start the server process
+    echo "[STARTUP] Starting Stremio server process"
     node server.js &
+    SERVER_PID=$!
+    echo "[STARTUP] Server started with PID: ${SERVER_PID}"
 
-    echo "Attempting to fetch HTTPS certificate for IP address: ${IPADDRESS}"
-    curl --connect-timeout 5 \
-         --retry-all-errors \
-         --retry 10 \
-         --retry-delay 1 \
-         --verbose \
-         "http://localhost:11470/get-https?authKey=&ipAddress=${IPADDRESS}"
-    CURL_STATUS="$?"
-    if [ "${CURL_STATUS}" -ne 0 ]; then
-        echo "Failed to fetch HTTPS certificate. Curl exited with status: ${CURL_STATUS}"
+    # Handle IP address resolution for "any address" values
+        echo "[STARTUP] IPADDRESS is set to '${IPADDRESS}' which indicates 'any address'"
+        PUBLIC_IP=$(get_public_ip)
+
+        # If we successfully obtained a public IP, use it instead of the original IPADDRESS
+        if [ -n "${PUBLIC_IP}" ]; then
+            echo "[STARTUP] Will use discovered public IP address: ${PUBLIC_IP} (replacing ${IPADDRESS})"
+            IPADDRESS="${PUBLIC_IP}"
+        else
+            echo "[STARTUP] ⚠ Failed to obtain public IP address, falling back to original value: ${IPADDRESS}"
+            echo "[STARTUP] ⚠ This may cause issues with certificate generation"
+        fi
     else
-        echo "Successfully fetched HTTPS certificate."
+        # Resolve domain name in IPADDRESS if needed
+        if ! echo "${IPADDRESS}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "[STARTUP] IPADDRESS '${IPADDRESS}' doesn't look like an IP address, attempting to resolve"
+            RESOLVED_IP=$(resolve_domain_to_ip "${IPADDRESS}")
+
+            if [ "${RESOLVED_IP}" != "${IPADDRESS}" ]; then
+                echo "[STARTUP] Resolved domain to IP: ${IPADDRESS} -> ${RESOLVED_IP}"
+                IPADDRESS="${RESOLVED_IP}"
+            else
+                echo "[STARTUP] ⚠ Could not resolve domain to IP, using as-is: ${IPADDRESS}"
+                echo "[STARTUP] ⚠ This may cause issues with certificate generation"
+            fi
+        else
+            echo "[STARTUP] Using provided IP address: ${IPADDRESS}"
+        fi
     fi
 
+    # Certificate setup for HTTPS
+    CERT_URL="http://localhost:11470/get-https?authKey=&ipAddress=${IPADDRESS}"
+    echo "[HTTPS] Attempting to fetch HTTPS certificate for IP: ${IPADDRESS}"
+    echo "[HTTPS] Using URL: ${CERT_URL}"
+
+    # Use set -x to show the exact curl command being executed
+    set -x
+    curl --connect-timeout 5 \
+        --retry-all-errors \
+        --retry 10 \
+        --retry-delay 1 \
+        --verbose \
+        "${CERT_URL}"
+    CURL_STATUS="$?"
+    set +x
+
+    if [ "${CURL_STATUS}" -ne 0 ]; then
+        echo "[HTTPS] ⚠ Failed to fetch HTTPS certificate. Curl exited with status: ${CURL_STATUS}"
+    else
+        echo "[HTTPS] ✓ Successfully requested HTTPS certificate"
+    fi
+
+    # Extract certificate information
+    echo "[HTTPS] Extracting certificate information from ${CONFIG_FOLDER}httpsCert.json"
     IMPORTED_DOMAIN="$(node certificate.js --action extract --json-path "${CONFIG_FOLDER}httpsCert.json")"
     EXTRACT_STATUS="$?"
     IMPORTED_CERT_FILE="${CONFIG_FOLDER}${IMPORTED_DOMAIN}.pem"
-    echo "Extracted domain ${IMPORTED_DOMAIN} with status ${EXTRACT_STATUS} and cert file ${IMPORTED_CERT_FILE}"
 
-    if [ "${EXTRACT_STATUS}" -eq 0 ] && [ -n "${IMPORTED_DOMAIN}" ] && [ -f "${IMPORTED_CERT_FILE}" ]; then
-        echo "${IPADDRESS} ${IMPORTED_DOMAIN}" >> /etc/hosts
+    if [ "${EXTRACT_STATUS}" -eq 0 ]; then
+        echo "[HTTPS] ✓ Successfully extracted domain from certificate: ${IMPORTED_DOMAIN}"
+        echo "[HTTPS] Certificate file location: ${IMPORTED_CERT_FILE}"
+
+        # Only update hosts file if UPDATE_HOSTS is set to true
+        if [ "${UPDATE_HOSTS:-false}" = "true" ]; then
+            echo "[HOSTS] Adding entry to /etc/hosts: '${IPADDRESS} ${IMPORTED_DOMAIN}'"
+            echo "${IPADDRESS} ${IMPORTED_DOMAIN}" >> /etc/hosts
+        fi
         
+        if [ -n "${IMPORTED_DOMAIN}" ] && [ -f "${IMPORTED_CERT_FILE}" ]; then
+        echo "[SERVER] Starting Web UI server with HTTPS enabled"
+        echo "[SERVER] Using certificate: ${IMPORTED_CERT_FILE}"
         start_http_server -S -C "${IMPORTED_CERT_FILE}" -K "${IMPORTED_CERT_FILE}"
     else
-        echo "Failed to setup HTTPS. Falling back to HTTP."
+            echo "[HTTPS] ⚠ Failed to setup HTTPS due to missing or invalid certificate"
+            echo "[HTTPS] ⚠ Attempting to start Web UI server with HTTP instead"
+            echo "[SERVER] Starting Web UI server with HTTP"
+            start_http_server
+        fi
+    else
+        echo "[HTTPS] ⚠ Failed to extract domain from certificate, exit code: ${EXTRACT_STATUS}"
+        echo "[HTTPS] ⚠ This may indicate a problem with the certificate generation process"
+        echo "[HTTPS] ⚠ Attempting to start Web UI server with HTTP instead"
+        echo "[SERVER] Starting Web UI server with HTTP"
         start_http_server
     fi
 elif [ -n "${CERT_FILE}" ] && [ -n "${DOMAIN}" ]; then


### PR DESCRIPTION
This is a more streamlined rewrite of the monstrosity that became #82 
Now I know what I'm doing. This PR has been working for me for the better part of two weeks now.

Here's what we've done:

- Introduced a new `docker-compose.traefik.yml` file to deploy Stremio and a streaming server behind a VPN using Gluetun, with Traefik as a reverse proxy.
- Configured environment variables for Traefik and Stremio, including ACME certificate resolver settings and DNS challenge provider.
- Set up health checks, logging, and resource limits for the Stremio service.
- Implemented Traefik routing rules for both HTTP and HTTPS streaming services.

What's actually been changed within `stremio-web-service-run.sh`

- Enhanced `stremio-web-service-run.sh` script for improved server management, including automatic public IP detection, domain resolution, and optional `hosts` file modification.
- Added detailed logging and error handling for server startup and configuration processes.
- Updated server.js patching logic to ensure proper configuration for proxy streams and disk space checks.

What you need to know:
- All of the new features are optional. Merging this PR will keep original functionality intact and maintain existing defaults.