### PR TITLE
update node

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -121,7 +121,7 @@ jobs:
           docker run -d --network custom_network --ip 172.18.0.3 -e CASTING_DISABLED=1 -e IPADDRESS=172.18.0.3 -v ~/.stremio-server:/root/.stremio-server --platform ${{ matrix.platform }} ${{ env.TMP_LOCAL_IMAGE }}:${platform//\//-}
           
           cd tests
-          sleep 30 # wait for server to startup
+          sleep 60 # wait for server to startup
 
           CONTAINER_ID=$(docker ps -a | grep stremio | awk '{print $1}')
           docker exec "$CONTAINER_ID" cat /etc/nginx/http.d/default.conf
@@ -143,7 +143,7 @@ jobs:
           docker run -d --network custom_network --ip 172.18.0.3 -e CASTING_DISABLED=1 -e IPADDRESS=172.18.0.3 -v ~/.stremio-server:/root/.stremio-server --platform ${{ matrix.platform }} ${{ env.TMP_LOCAL_IMAGE }}:${platform//\//-}
           
           cd tests
-          sleep 30 # wait for server to startup
+          sleep 60 # wait for server to startup
           
           CONTAINER_ID=$(docker ps -a | grep stremio | awk '{print $1}')
           docker exec "$CONTAINER_ID" cat /etc/nginx/http.d/default.conf

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -121,7 +121,7 @@ jobs:
           docker run -d --network custom_network --ip 172.18.0.3 -e CASTING_DISABLED=1 -e IPADDRESS=172.18.0.3 -v ~/.stremio-server:/root/.stremio-server --platform ${{ matrix.platform }} ${{ env.TMP_LOCAL_IMAGE }}:${platform//\//-}
           
           cd tests
-          sleep 15 # wait for server to startup
+          sleep 30 # wait for server to startup
 
           CONTAINER_ID=$(docker ps -a | grep stremio | awk '{print $1}')
           docker exec "$CONTAINER_ID" cat /etc/nginx/http.d/default.conf
@@ -143,7 +143,7 @@ jobs:
           docker run -d --network custom_network --ip 172.18.0.3 -e CASTING_DISABLED=1 -e IPADDRESS=172.18.0.3 -v ~/.stremio-server:/root/.stremio-server --platform ${{ matrix.platform }} ${{ env.TMP_LOCAL_IMAGE }}:${platform//\//-}
           
           cd tests
-          sleep 15 # wait for server to startup
+          sleep 30 # wait for server to startup
           
           CONTAINER_ID=$(docker ps -a | grep stremio | awk '{print $1}')
           docker exec "$CONTAINER_ID" cat /etc/nginx/http.d/default.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# We use node:18-alpine3.18 because it's the only one that supports the build-base package for ffmpeg. Changing to 3.21 will require a new ffmpeg build.
-FROM node:18-alpine3.18 AS base
+# We use node:20-alpine3.18 because it's the only one that supports the build-base package for ffmpeg. Changing to 3.21 will require a new ffmpeg build.
+FROM node:20-alpine3.18 AS base
 
 RUN apk update && apk upgrade
 


### PR DESCRIPTION
```
45.82 error minimatch@10.0.3: The engine "node" is incompatible with this module. Expected version "20 || >=22". Got "18.20.3"
45.84 error Found incompatible module.
45.84 info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```