### PR TITLE
Test/gpu nvidia

### DIFF
--- a/Dockerfile.nvidia
+++ b/Dockerfile.nvidia
@@ -1,0 +1,150 @@
+# NVIDIA GPU-accelerated variant using CUDA + NVENC
+# Requires: nvidia-container-toolkit on the host
+FROM nvidia/cuda:12.2.2-devel-ubuntu22.04 AS ffmpeg
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  build-essential git nasm yasm pkg-config \
+  libgnutls28-dev libfreetype6-dev libass-dev \
+  libogg-dev libtheora-dev libvorbis-dev libvpx-dev \
+  libwebp-dev libopus-dev libx264-dev libx265-dev \
+  libmp3lame-dev libfdk-aac-dev libdav1d-dev \
+  libbluray-dev libdrm-dev libzimg-dev libaom-dev \
+  libxvidcore-dev librtmp-dev libva-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV BIN="/usr/bin"
+RUN cd && \
+  DIR=$(mktemp -d) && cd "${DIR}" && \
+  git clone --depth 1 --branch v4.4.1-4 https://github.com/jellyfin/jellyfin-ffmpeg.git && \
+  cd jellyfin-ffmpeg* && \
+  PATH="$BIN:$PATH" && \
+  ./configure --bindir="$BIN" --disable-debug \
+  --prefix=/usr/lib/jellyfin-ffmpeg \
+  --extra-version=Jellyfin --disable-doc --disable-ffplay --disable-shared \
+  --disable-libxcb --disable-sdl2 --disable-xlib \
+  --enable-lto --enable-gpl --enable-version3 \
+  --enable-gmp --enable-gnutls --enable-libdrm \
+  --enable-libass --enable-libfreetype --enable-libfribidi \
+  --enable-libfontconfig --enable-libbluray \
+  --enable-libmp3lame --enable-libopus --enable-libtheora \
+  --enable-libvorbis --enable-libdav1d --enable-libwebp \
+  --enable-libvpx --enable-libx264 --enable-libx265 \
+  --enable-libzimg --enable-small --enable-nonfree \
+  --enable-libxvid --enable-libaom --enable-libfdk_aac \
+  --enable-vaapi \
+  --enable-hwaccel=h264_vaapi --enable-hwaccel=hevc_vaapi \
+  --enable-cuda-nvcc --enable-nvenc --enable-nvdec \
+  --enable-cuvid --enable-libnpp \
+  --extra-cflags="-I/usr/local/cuda/include" \
+  --extra-ldflags="-L/usr/local/cuda/lib64" \
+  --toolchain=hardened && \
+  make -j$(nproc) && \
+  make install && \
+  make distclean && \
+  rm -rf "${DIR}"
+
+#########################################################################
+
+# Builder image (same as original)
+FROM node:20-alpine3.18 AS builder-web
+
+WORKDIR /srv
+RUN apk add --no-cache git wget
+
+ARG BRANCH=development
+RUN REPO="https://github.com/Stremio/stremio-web.git"; if [ "$BRANCH" == "release" ];then git clone "$REPO" --depth 1 --branch $(git ls-remote --tags --refs $REPO | awk '{print $2}' | sort -V | tail -n1 | cut -d/ -f3); else git clone --depth 1 --branch "$BRANCH" https://github.com/Stremio/stremio-web.git; fi
+
+WORKDIR /srv/stremio-web
+
+COPY ./load_localStorage.js ./src/load_localStorage.js
+RUN sed -i "/entry: {/a \\        loader: './src/load_localStorage.js'," webpack.config.js
+
+RUN npm install -g pnpm --force
+RUN pnpm install --frozen-lockfile --reporter=silent
+RUN pnpm run build
+
+RUN wget $(wget -O- https://raw.githubusercontent.com/Stremio/stremio-shell/master/server-url.txt) && wget -mkEpnp -nH "https://app.strem.io/" "https://app.strem.io/worker.js" "https://app.strem.io/images/stremio.png" "https://app.strem.io/images/empty.png" -P build/shell/ || true
+
+##########################################################################
+
+# Main image - NVIDIA runtime
+FROM nvidia/cuda:12.2.2-runtime-ubuntu22.04 AS final
+
+ARG VERSION=main
+LABEL org.opencontainers.image.source=https://github.com/tsaridas/stremio-docker
+LABEL org.opencontainers.image.description="Stremio Web Player and Server (NVIDIA GPU)"
+LABEL org.opencontainers.image.licenses=MIT
+LABEL version=${VERSION}
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install Node.js 20
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl gnupg \
+  && mkdir -p /etc/apt/keyrings \
+  && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+  && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
+  && apt-get update && apt-get install -y --no-install-recommends \
+  nodejs nginx apache2-utils curl \
+  libfreetype6 libass9 libvorbis0a libvorbisenc2 \
+  libx265-199 libx264-163 libopus0 libmp3lame0 \
+  libgnutls30 libvpx7 libtheora0 libdrm2 \
+  libbluray2 libzimg2 libdav1d5 libaom3 \
+  libxvidcore4 libfdk-aac2 libwebp7 libva2 libva-drm2 \
+  && rm -rf /var/lib/apt/lists/*
+
+# Match Alpine nginx directory structure used by stremio scripts
+RUN mkdir -p /etc/nginx/http.d && \
+    rm -f /etc/nginx/sites-enabled/default
+
+WORKDIR /srv/stremio-server
+COPY --from=builder-web /srv/stremio-web/build ./build
+COPY --from=builder-web /srv/stremio-web/server.js ./
+
+COPY ./nginx/ /etc/nginx/
+COPY ./stremio-web-service-run.sh ./
+COPY ./certificate.js ./
+RUN chmod +x stremio-web-service-run.sh
+COPY ./restart_if_idle.sh ./
+RUN chmod +x restart_if_idle.sh
+COPY localStorage.json ./
+
+ENV FFMPEG_BIN=
+ENV FFPROBE_BIN=
+ENV WEBUI_LOCATION=
+ENV WEBUI_INTERNAL_PORT=
+ENV OPEN=
+ENV HLS_DEBUG=
+ENV DEBUG=
+ENV DEBUG_MIME=
+ENV DEBUG_FD=
+ENV FFMPEG_DEBUG=
+ENV FFSPLIT_DEBUG=
+ENV NODE_DEBUG=
+ENV NODE_ENV=production
+ENV HTTPS_CERT_ENDPOINT=
+ENV DISABLE_CACHING=
+ENV READABLE_STREAM=
+ENV APP_PATH=
+ENV NO_CORS=1
+ENV CASTING_DISABLED=
+ENV IPADDRESS=
+ENV DOMAIN=
+ENV CERT_FILE=
+ENV SERVER_URL=
+ENV AUTO_SERVER_URL=0
+
+# NVIDIA env vars for container toolkit
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,video,utility
+
+# Copy ffmpeg built with NVENC
+COPY --from=ffmpeg /usr/bin/ffmpeg /usr/bin/ffprobe /usr/bin/
+COPY --from=ffmpeg /usr/lib/jellyfin-ffmpeg /usr/lib/
+
+VOLUME ["/root/.stremio-server"]
+EXPOSE 8080
+
+ENTRYPOINT []
+CMD ["./stremio-web-service-run.sh"]

--- a/Dockerfile.nvidia
+++ b/Dockerfile.nvidia
@@ -15,6 +15,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 ENV BIN="/usr/bin"
+ENV PATH="/usr/local/cuda/bin:${PATH}"
+
+# Install nv-codec-headers (ffnvcodec) required by NVENC/NVDEC/CUVID
+RUN cd /tmp && \
+  git clone --depth 1 --branch n12.0.16.1 https://github.com/FFmpeg/nv-codec-headers.git && \
+  cd nv-codec-headers && make install && \
+  rm -rf /tmp/nv-codec-headers
+
 RUN cd && \
   DIR=$(mktemp -d) && cd "${DIR}" && \
   git clone --depth 1 --branch v4.4.1-4 https://github.com/jellyfin/jellyfin-ffmpeg.git && \
@@ -37,6 +45,7 @@ RUN cd && \
   --enable-hwaccel=h264_vaapi --enable-hwaccel=hevc_vaapi \
   --enable-cuda-nvcc --enable-nvenc --enable-nvdec \
   --enable-cuvid --enable-libnpp \
+  --nvccflags="-gencode arch=compute_52,code=sm_52 -O2" \
   --extra-cflags="-I/usr/local/cuda/include" \
   --extra-ldflags="-L/usr/local/cuda/lib64" \
   --toolchain=hardened && \
@@ -91,11 +100,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
   libx265-199 libx264-163 libopus0 libmp3lame0 \
   libgnutls30 libvpx7 libtheora0 libdrm2 \
   libbluray2 libzimg2 libdav1d5 libaom3 \
-  libxvidcore4 libfdk-aac2 libwebp7 libva2 libva-drm2 \
+  libxvidcore4 libfdk-aac2 libwebp7 libwebpmux3 libva2 libva-drm2 \
   && rm -rf /var/lib/apt/lists/*
 
 # Match Alpine nginx directory structure used by stremio scripts
-RUN mkdir -p /etc/nginx/http.d && \
+RUN useradd -r -s /bin/false nginx && \
+    mkdir -p /etc/nginx/http.d && \
     rm -f /etc/nginx/sites-enabled/default
 
 WORKDIR /srv/stremio-server

--- a/NVIDIA-GPU.md
+++ b/NVIDIA-GPU.md
@@ -152,11 +152,19 @@ watch -n1 "docker exec $(docker ps --filter 'ancestor=stremio-docker:nvidia' -q)
 
 ### Perfil nvenc-linux (pipeline ffmpeg)
 
-O perfil `nvenc-linux` no server.js do Stremio usa:
-- **Decode:** `hevc_cuvid`, `h264_cuvid`, `av1_cuvid` (GPU)
-- **Scale:** `scale_cuda` (GPU)
-- **Encode:** `h264_nvenc`, `hevc_nvenc` (GPU)
-- **Args:** `-init_hw_device cuda=cu:0 -filter_hw_device cu -hwaccel cuda -hwaccel_output_format cuda`
+O perfil `nvenc-linux` é patcheado em runtime pelo entrypoint para compatibilidade 10-bit (Pascal/GTX 1070):
+
+- **Decode:** `hevc_cuvid`, `h264_cuvid`, `av1_cuvid` (GPU — ffmpeg auto-downloads para memória sistema)
+- **Scale:** CPU `scale` com lanczos (necessário para 10-bit → 8-bit)
+- **Encode:** `h264_nvenc` preset p1, tune ull (GPU — aceita frames de memória sistema)
+- **Args:** `-hwaccel cuda`
+
+Pipeline: HW decode (CUVID) → auto-download → CPU scale/format → NVENC encode
+
+> **Nota sobre 10-bit:** O GTX 1070 (Pascal) não suporta encode H.264 10-bit via NVENC.
+> O perfil original usava `scale_cuda` + `hwaccel_output_format cuda` que mantém frames 10-bit
+> em memória CUDA, causando falha no encoder. O patch remove esses flags e usa CPU scale
+> para converter 10-bit → 8-bit antes do encode.
 
 ## Rebuild / Atualização
 
@@ -187,23 +195,16 @@ docker compose -f compose.yaml up -d
 # 4. Aguardar inicialização (~10s)
 sleep 10
 
-# 5. Verificar se GPU funciona
+# 5. Verificar GPU + patches
+docker logs stremio-docker-stremio-1 2>&1 | grep NVENC
+docker exec $(docker ps --filter "ancestor=stremio-docker:nvidia" -q) nvidia-smi
+
+# 6. Verificar settings
 docker exec $(docker ps --filter "ancestor=stremio-docker:nvidia" -q) \
-  ffmpeg -hwaccels 2>&1 | grep cuda
-
-# 6. Re-aplicar configuração NVENC (se teste automático falhar)
-docker exec $(docker ps --filter "ancestor=stremio-docker:nvidia" -q) sed -i \
-  -e 's/"transcodeHardwareAccel": false/"transcodeHardwareAccel": true/' \
-  -e 's/"transcodeProfile": null/"transcodeProfile": "nvenc-linux"/' \
-  -e 's/"allTranscodeProfiles": \[\]/"allTranscodeProfiles": ["nvenc-linux"]/' \
-  /root/.stremio-server/server-settings.json
-
-# 7. Reiniciar para aplicar
-docker compose -f compose.yaml restart
-
-# 8. Confirmar tudo ok
-docker logs stremio-docker-stremio-1 2>&1 | tail -5
+  grep -E 'transcodeHardware|transcodeProfile' /root/.stremio-server/server-settings.json
 ```
+
+> **Nota:** O entrypoint patcha `server.js` automaticamente a cada restart — não é mais necessário re-aplicar settings manualmente.
 
 ### Atualizar versão CUDA
 
@@ -227,7 +228,8 @@ Também verificar compatibilidade de `nv-codec-headers` (branch no git clone).
 | `getpwnam("nginx") failed` | `useradd -r -s /bin/false nginx` | Dockerfile.nvidia |
 | `libwebpmux.so.3: cannot open` | Adicionado `libwebpmux3` aos pacotes | Dockerfile.nvidia |
 | `Bad substitution` (dash vs bash) | `case` POSIX em vez de `${var: -1}` | stremio-web-service-run.sh |
-| Teste hwaccel falha (sample curto) | Configuração manual em server-settings.json | Pós-deploy |
+| Teste hwaccel falha (sample curto) | Patch `server.js`: `transcodeHardwareAccel:!1` → `!0` | stremio-web-service-run.sh |
+| 10-bit NVENC fail (Pascal GPU) | Patch perfil: remove `scale_cuda`/`hwaccel_output_format`, usa CPU scale | stremio-web-service-run.sh |
 
 ## Ambiente atual
 

--- a/NVIDIA-GPU.md
+++ b/NVIDIA-GPU.md
@@ -1,0 +1,238 @@
+# Stremio Docker — NVIDIA GPU (NVENC/NVDEC)
+
+Guia completo para build, deploy e manutenção da imagem Stremio com aceleração GPU NVIDIA.
+
+## Pré-requisitos no Host
+
+- Driver NVIDIA >= 535 (`nvidia-smi` deve funcionar)
+- [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) instalado
+- Docker com runtime `nvidia` configurado (`docker info | grep nvidia`)
+
+```bash
+# Verificar pré-requisitos
+nvidia-smi
+docker info | grep -i "runtimes.*nvidia"
+```
+
+## Arquitetura
+
+```
+┌─────────────────────────────────────────────────────┐
+│  compose.yaml                                       │
+│  ├── build: Dockerfile.nvidia                       │
+│  ├── runtime: nvidia                                │
+│  └── deploy.resources (CPU/RAM/GPU limits)          │
+├─────────────────────────────────────────────────────┤
+│  Dockerfile.nvidia (multi-stage)                    │
+│  ├── Stage 1: ffmpeg     (cuda:12.2.2-devel)        │
+│  │   ├── nv-codec-headers (ffnvcodec n12.0.16.1)   │
+│  │   └── jellyfin-ffmpeg v4.4.1-4                   │
+│  │       └── NVENC + NVDEC + CUVID + VAAPI          │
+│  ├── Stage 2: builder-web (node:20-alpine)          │
+│  │   └── stremio-web (pnpm build)                   │
+│  └── Stage 3: final     (cuda:12.2.2-runtime)       │
+│      ├── Node.js 20 + nginx + ffmpeg binaries       │
+│      └── stremio-web-service-run.sh                 │
+└─────────────────────────────────────────────────────┘
+```
+
+## Build
+
+```bash
+# Build padrão
+docker compose -f compose.yaml build
+
+# Build sem cache (após mudar base images)
+docker compose -f compose.yaml build --no-cache
+
+# Build com branch específico do stremio-web
+docker compose -f compose.yaml build --build-arg BRANCH=release
+```
+
+**Tempo de build:** ~5-10 min (ffmpeg com CUDA é o mais demorado).
+
+## Deploy
+
+```bash
+# Subir o container
+docker compose -f compose.yaml up -d
+
+# Ver logs
+docker logs -f stremio-docker-stremio-1
+
+# Reiniciar
+docker compose -f compose.yaml restart
+
+# Parar
+docker compose -f compose.yaml down
+```
+
+**Acesso:** `https://stremio.raspberrypi.lan/` (porta 8085 no host → 8080 no container)
+
+## Limites de Recursos (compose.yaml)
+
+```yaml
+deploy:
+  resources:
+    limits:
+      cpus: "2.0"        # Max 2 cores (de 4 disponíveis)
+      memory: 2G          # Max 2GB RAM (de 15GB disponíveis)
+    reservations:
+      memory: 512M        # Mínimo garantido
+      devices:
+        - driver: nvidia
+          count: 1         # 1 GPU (GTX 1070 8GB)
+          capabilities: [gpu, video, compute]
+```
+
+Para ajustar limites, edite `compose.yaml` e rode:
+```bash
+docker compose -f compose.yaml up -d   # aplica sem rebuild
+```
+
+## Configuração GPU / Transcoding
+
+### Verificação rápida
+
+```bash
+CONTAINER=$(docker ps --filter "ancestor=stremio-docker:nvidia" -q)
+
+# GPU visível?
+docker exec $CONTAINER nvidia-smi
+
+# ffmpeg com NVENC?
+docker exec $CONTAINER ffmpeg -hwaccels 2>&1 | grep cuda
+docker exec $CONTAINER ffmpeg -encoders 2>/dev/null | grep nvenc
+docker exec $CONTAINER ffmpeg -decoders 2>/dev/null | grep cuvid
+
+# Libs ok?
+docker exec $CONTAINER sh -c 'ldd /usr/bin/ffmpeg | grep "not found"'
+```
+
+### server-settings.json
+
+O Stremio guarda configurações de transcoding em `/root/.stremio-server/server-settings.json` (persistido no volume).
+
+**Campos relevantes:**
+```json
+{
+    "transcodeHardwareAccel": true,
+    "transcodeProfile": "nvenc-linux",
+    "allTranscodeProfiles": ["nvenc-linux"],
+    "transcodeConcurrency": 1,
+    "transcodeMaxWidth": 1920,
+    "transcodeMaxBitRate": 0
+}
+```
+
+**Problema conhecido:** O teste automático de hwaccel do Stremio falha com o sample curto (0.2s) e marca `transcodeHardwareAccel: false`. Se isso acontecer após rebuild:
+
+```bash
+CONTAINER=$(docker ps --filter "ancestor=stremio-docker:nvidia" -q)
+
+# Forçar NVENC
+docker exec $CONTAINER sed -i \
+  -e 's/"transcodeHardwareAccel": false/"transcodeHardwareAccel": true/' \
+  -e 's/"transcodeProfile": null/"transcodeProfile": "nvenc-linux"/' \
+  -e 's/"allTranscodeProfiles": \[\]/"allTranscodeProfiles": ["nvenc-linux"]/' \
+  /root/.stremio-server/server-settings.json
+
+# Reiniciar para aplicar
+docker compose -f compose.yaml restart
+```
+
+### Monitorar uso de GPU durante streaming
+
+```bash
+# Tempo real
+watch -n1 "docker exec $(docker ps --filter 'ancestor=stremio-docker:nvidia' -q) nvidia-smi"
+```
+
+> **Nota:** A GPU só é usada quando há transcoding (ex: HEVC→H264, mudança de resolução). Se o player suporta o codec nativo, o stream vai direto sem ffmpeg.
+
+### Perfil nvenc-linux (pipeline ffmpeg)
+
+O perfil `nvenc-linux` no server.js do Stremio usa:
+- **Decode:** `hevc_cuvid`, `h264_cuvid`, `av1_cuvid` (GPU)
+- **Scale:** `scale_cuda` (GPU)
+- **Encode:** `h264_nvenc`, `hevc_nvenc` (GPU)
+- **Args:** `-init_hw_device cuda=cu:0 -filter_hw_device cu -hwaccel cuda -hwaccel_output_format cuda`
+
+## Rebuild / Atualização
+
+### Quando rebuildar?
+
+| Situação | Comando |
+|---|---|
+| Atualizar stremio-web | `docker compose build --no-cache` |
+| Atualizar CUDA base image | Editar versão no Dockerfile.nvidia, depois `build --no-cache` |
+| Mudar configuração de compose | `docker compose up -d` (sem rebuild) |
+| Mudar nginx/scripts/env | `docker compose build` (cache parcial) |
+| Atualizar driver NVIDIA no host | Reiniciar container apenas |
+
+### Passo a passo para rebuild completo
+
+```bash
+cd /home/lgldsilva/backup-dietpi-home/stremio-docker
+
+# 1. Parar container
+docker compose -f compose.yaml down
+
+# 2. Rebuild (--no-cache se atualizar base images)
+docker compose -f compose.yaml build --no-cache
+
+# 3. Subir novamente
+docker compose -f compose.yaml up -d
+
+# 4. Aguardar inicialização (~10s)
+sleep 10
+
+# 5. Verificar se GPU funciona
+docker exec $(docker ps --filter "ancestor=stremio-docker:nvidia" -q) \
+  ffmpeg -hwaccels 2>&1 | grep cuda
+
+# 6. Re-aplicar configuração NVENC (se teste automático falhar)
+docker exec $(docker ps --filter "ancestor=stremio-docker:nvidia" -q) sed -i \
+  -e 's/"transcodeHardwareAccel": false/"transcodeHardwareAccel": true/' \
+  -e 's/"transcodeProfile": null/"transcodeProfile": "nvenc-linux"/' \
+  -e 's/"allTranscodeProfiles": \[\]/"allTranscodeProfiles": ["nvenc-linux"]/' \
+  /root/.stremio-server/server-settings.json
+
+# 7. Reiniciar para aplicar
+docker compose -f compose.yaml restart
+
+# 8. Confirmar tudo ok
+docker logs stremio-docker-stremio-1 2>&1 | tail -5
+```
+
+### Atualizar versão CUDA
+
+Editar em `Dockerfile.nvidia`:
+```dockerfile
+# Stage 1 (build): usar devel da versão desejada
+FROM nvidia/cuda:<VERSION>-devel-ubuntu22.04 AS ffmpeg
+
+# Stage 3 (runtime): usar runtime da mesma versão
+FROM nvidia/cuda:<VERSION>-runtime-ubuntu22.04 AS final
+```
+
+Também verificar compatibilidade de `nv-codec-headers` (branch no git clone).
+
+## Correções aplicadas (vs Dockerfile original)
+
+| Problema | Correção | Arquivo |
+|---|---|---|
+| `nvcc fatal: Unsupported gpu architecture 'compute_30'` | `--nvccflags="-gencode arch=compute_52,code=sm_52 -O2"` | Dockerfile.nvidia |
+| `cuvid requested, but not all dependencies are satisfied: ffnvcodec` | Instalação de `nv-codec-headers n12.0.16.1` | Dockerfile.nvidia |
+| `getpwnam("nginx") failed` | `useradd -r -s /bin/false nginx` | Dockerfile.nvidia |
+| `libwebpmux.so.3: cannot open` | Adicionado `libwebpmux3` aos pacotes | Dockerfile.nvidia |
+| `Bad substitution` (dash vs bash) | `case` POSIX em vez de `${var: -1}` | stremio-web-service-run.sh |
+| Teste hwaccel falha (sample curto) | Configuração manual em server-settings.json | Pós-deploy |
+
+## Ambiente atual
+
+- **Host:** DietPi Linux, 4 CPUs, 15GB RAM
+- **GPU:** NVIDIA GeForce GTX 1070 (8GB VRAM)
+- **Driver:** 535.288.01 / CUDA 12.2
+- **Volume:** `/mnt/lvm1-storage/.stremio-server` (2.7TB, 755GB livre)
+- **Acesso:** `https://stremio.raspberrypi.lan/` (porta 8085)

--- a/NVIDIA-GPU.md
+++ b/NVIDIA-GPU.md
@@ -1,6 +1,27 @@
 # Stremio Docker — NVIDIA GPU (NVENC/NVDEC)
 
-Guia completo para build, deploy e manutenção da imagem Stremio com aceleração GPU NVIDIA.
+Guia completo para build, deploy, manutenção e troubleshooting da imagem Stremio com
+aceleração GPU NVIDIA. Inclui documentação detalhada de todos os problemas encontrados,
+soluções aplicadas e abordagens que **não funcionaram** — para evitar repetir erros.
+
+---
+
+## Índice
+
+1. [Pré-requisitos](#pré-requisitos-no-host)
+2. [Arquitetura](#arquitetura)
+3. [Build](#build)
+4. [Deploy](#deploy)
+5. [Limites de Recursos](#limites-de-recursos)
+6. [Configuração GPU / Transcoding](#configuração-gpu--transcoding)
+7. [Patches Runtime (server.js)](#patches-runtime-serverjs)
+8. [Rebuild / Atualização](#rebuild--atualização)
+9. [O que NÃO funcionou (lições aprendidas)](#o-que-não-funcionou-lições-aprendidas)
+10. [Correções aplicadas (resumo)](#correções-aplicadas-resumo)
+11. [Referência técnica](#referência-técnica)
+12. [Ambiente atual](#ambiente-atual)
+
+---
 
 ## Pré-requisitos no Host
 
@@ -32,8 +53,31 @@ docker info | grep -i "runtimes.*nvidia"
 │  │   └── stremio-web (pnpm build)                   │
 │  └── Stage 3: final     (cuda:12.2.2-runtime)       │
 │      ├── Node.js 20 + nginx + ffmpeg binaries       │
-│      └── stremio-web-service-run.sh                 │
+│      └── stremio-web-service-run.sh (entrypoint)    │
 └─────────────────────────────────────────────────────┘
+```
+
+### Pipeline de transcoding (após patches)
+
+```
+Arquivo de vídeo (ex: HEVC 10-bit)
+    │
+    ▼
+[GPU] CUVID decode (hevc_cuvid / h264_cuvid / av1_cuvid)
+    │
+    ▼ auto-download para memória sistema (ffmpeg faz isso automaticamente
+    │ quando não há -hwaccel_output_format cuda)
+    │
+    ▼
+[CPU] scale (lanczos) + format conversion (10-bit p010 → 8-bit yuv420p)
+    │
+    ▼ auto-upload para GPU (h264_nvenc aceita system memory frames)
+    │
+    ▼
+[GPU] NVENC encode (h264_nvenc, preset p1, tune ull)
+    │
+    ▼
+HLS output → player
 ```
 
 ## Build
@@ -51,6 +95,16 @@ docker compose -f compose.yaml build --build-arg BRANCH=release
 
 **Tempo de build:** ~5-10 min (ffmpeg com CUDA é o mais demorado).
 
+### Problemas de build resolvidos
+
+| Erro | Causa | Solução |
+|------|-------|---------|
+| `nvcc fatal: Unsupported gpu architecture 'compute_30'` | CUDA 12.x removeu suporte a compute_30 | `--nvccflags="-gencode arch=compute_52,code=sm_52 -O2"` (Maxwell+) |
+| `cuvid requested, but not all dependencies are satisfied: ffnvcodec` | ffmpeg precisa de `nv-codec-headers` para compilar NVENC/NVDEC | Instalação manual do `nv-codec-headers` branch `n12.0.16.1` do GitHub |
+| `getpwnam("nginx") failed` | Ubuntu não cria user `nginx` (Alpine sim) | `useradd -r -s /bin/false nginx` no Dockerfile |
+| `libwebpmux.so.3: cannot open shared object file` | Ubuntu 22.04 separa `libwebpmux3` de `libwebp7` | Adicionado `libwebpmux3` explicitamente nos pacotes |
+| `Bad substitution` no entrypoint | `Dockerfile` usa `/bin/sh` que é `dash` no Ubuntu, não `bash` | Trocado `${var: -1}` (bash-only) por `case "$var" in ... esac` (POSIX) |
+
 ## Deploy
 
 ```bash
@@ -60,7 +114,7 @@ docker compose -f compose.yaml up -d
 # Ver logs
 docker logs -f stremio-docker-stremio-1
 
-# Reiniciar
+# Reiniciar (re-aplica patches server.js automaticamente)
 docker compose -f compose.yaml restart
 
 # Parar
@@ -69,21 +123,35 @@ docker compose -f compose.yaml down
 
 **Acesso:** `https://stremio.raspberrypi.lan/` (porta 8085 no host → 8080 no container)
 
-## Limites de Recursos (compose.yaml)
+## Limites de Recursos
 
 ```yaml
 deploy:
   resources:
     limits:
-      cpus: "2.0"        # Max 2 cores (de 4 disponíveis)
-      memory: 2G          # Max 2GB RAM (de 15GB disponíveis)
+      cpus: "1.5"        # 1.5 cores (NVENC offload → CPU só faz áudio/decode)
+      memory: 1536M       # 1.5GB (pico medido: 1.35GB durante transcode)
     reservations:
-      memory: 512M        # Mínimo garantido
+      memory: 256M        # Mínimo garantido (idle ~200MB: node + nginx)
       devices:
         - driver: nvidia
           count: 1         # 1 GPU (GTX 1070 8GB)
           capabilities: [gpu, video, compute]
 ```
+
+### Consumo medido durante transcoding ativo
+
+| Processo | CPU | RAM (RSS) | GPU |
+|----------|-----|-----------|-----|
+| ffmpeg áudio (aac) | ~30% | ~1.15 GB | — |
+| ffmpeg vídeo (NVENC) | ~60% | ~234 MB | 15%, 868 MiB VRAM |
+| node server.js | ~40% | ~185 MB | — |
+| nginx | ~1% | ~28 MB | — |
+| **Total** | **~138%** | **~1.35 GB** | **15% util** |
+
+> **Por que 1.5 cores basta?** Com NVENC, o encode de vídeo (a parte mais pesada) roda na GPU.
+> A CPU só faz decode de áudio, encode aac, e algum processamento de scale.
+> Antes (libx264 software), o CPU ficava em 100%+ só com encode.
 
 Para ajustar limites, edite `compose.yaml` e rode:
 ```bash
@@ -109,9 +177,33 @@ docker exec $CONTAINER ffmpeg -decoders 2>/dev/null | grep cuvid
 docker exec $CONTAINER sh -c 'ldd /usr/bin/ffmpeg | grep "not found"'
 ```
 
+### Verificar se transcoding está usando GPU
+
+```bash
+CONTAINER=$(docker ps --filter "ancestor=stremio-docker:nvidia" -q)
+
+# Ver processos ffmpeg dentro do container
+docker exec $CONTAINER ps aux | grep ffmpeg
+
+# Procurar h264_nvenc nos argumentos (GPU) vs libx264 (software)
+docker exec $CONTAINER sh -c 'for pid in $(pgrep ffmpeg); do
+  echo "=== PID $pid ==="
+  cat /proc/$pid/cmdline | tr "\0" " "
+  echo
+done'
+
+# Monitor GPU em tempo real
+watch -n1 "docker exec $CONTAINER nvidia-smi"
+```
+
+> **Se ffmpeg mostra `-c:v libx264` em vez de `h264_nvenc`:** O auto-test pode ter desabilitado
+> hw accel. Verificar se os patches do entrypoint foram aplicados (logs devem mostrar
+> `"NVENC: patched server.js"`). Reiniciar o container para re-aplicar.
+
 ### server-settings.json
 
-O Stremio guarda configurações de transcoding em `/root/.stremio-server/server-settings.json` (persistido no volume).
+O Stremio guarda configurações de transcoding em `/root/.stremio-server/server-settings.json`
+(persistido no volume).
 
 **Campos relevantes:**
 ```json
@@ -125,46 +217,105 @@ O Stremio guarda configurações de transcoding em `/root/.stremio-server/server
 }
 ```
 
-**Problema conhecido:** O teste automático de hwaccel do Stremio falha com o sample curto (0.2s) e marca `transcodeHardwareAccel: false`. Se isso acontecer após rebuild:
+> **Nota:** A GPU só é usada quando há transcoding (ex: HEVC→H264, mudança de resolução).
+> Se o player suporta o codec nativo, o stream vai direto sem ffmpeg.
+
+## Patches Runtime (server.js)
+
+O arquivo `stremio-web-service-run.sh` (entrypoint do container) aplica patches no `server.js`
+do Stremio **antes** de iniciar o processo node. Isso é necessário porque o server.js é um
+bundle webpack minificado e não podemos modificar o source do Stremio diretamente.
+
+Os patches são re-aplicados automaticamente a cada restart/recreação do container.
+
+### Patch 1: Neutralizar auto-test de hardware acceleration
+
+**Problema:** O Stremio tem um auto-test que verifica se o hardware acceleration funciona.
+Ele transcodifica um sample HEVC de 0.2 segundos. Esse teste **sempre falha** porque:
+- O sample é muito curto (0.2s)
+- Há um bug de race condition com o limite de concorrência
+- O ffmpeg retorna "Error: stream ended" antes de produzir output suficiente
+
+Quando o teste falha, o Stremio executa `saveSettings({transcodeHardwareAccel: !1})` que:
+1. Seta `userSettings.transcodeHardwareAccel = false` **em memória**
+2. Grava `false` no `server-settings.json` em disco
+
+**Por que isso é difícil de corrigir:**
+- O `saveSettings()` atualiza o estado **em memória** do processo node
+- Editar o arquivo `server-settings.json` depois não adianta — o node já leu o valor
+- O auto-test roda em 2 momentos: startup (`initialDetection`) E com callback (`expectResult`)
+- Mesmo desabilitando `initialDetection`, o teste com callback ainda roda
+
+**Solução:** Trocar TODAS as instâncias de `transcodeHardwareAccel: !1` (false) para
+`transcodeHardwareAccel: !0` (true) no server.js minificado:
 
 ```bash
-CONTAINER=$(docker ps --filter "ancestor=stremio-docker:nvidia" -q)
+sed -i 's/transcodeHardwareAccel: !1/transcodeHardwareAccel: !0/g' server.js
+```
 
-# Forçar NVENC
-docker exec $CONTAINER sed -i \
+Isso garante que mesmo quando o auto-test falha e chama `saveSettings()`,
+o valor gravado é `true` (tanto em memória quanto em disco).
+
+### Patch 2: Perfil nvenc-linux — compatibilidade 10-bit (Pascal)
+
+**Problema:** GPUs Pascal (GTX 1070, 1080, etc.) não suportam encode H.264 10-bit via NVENC.
+O perfil original do Stremio usa:
+```
+-hwaccel cuda -hwaccel_output_format cuda -init_hw_device cuda=cu:0 -filter_hw_device cu
+```
+Com `-hwaccel_output_format cuda`, os frames decodificados ficam em memória CUDA no formato
+nativo (p010le para HEVC 10-bit). O `h264_nvenc` no Pascal rejeita frames 10-bit com erro:
+```
+10 bit encode not supported
+Provided device doesn't support required NVENC features
+```
+
+**Solução (6 substituições no server.js):**
+
+```bash
+# 1. Remove -hwaccel_output_format cuda
+#    Sem isso, ffmpeg auto-downloads frames CUDA para system memory
+sed -i 's/"-hwaccel", "cuda", "-hwaccel_output_format", "cuda"/"-hwaccel", "cuda"/' server.js
+
+# 2. Remove -init_hw_device/-filter_hw_device
+#    Só eram necessários para scale_cuda (que não usamos mais)
+sed -i 's/"-init_hw_device", "cuda=cu:0", "-filter_hw_device", "cu", "-hwaccel"/"-hwaccel"/' server.js
+
+# 3. Desabilita scale_cuda (usa CPU scale com conversão automática 10→8 bit)
+sed -i 's/scale: "scale_cuda"/scale: !1/' server.js
+
+# 4. Adiciona flags lanczos ao CPU scale (qualidade)
+sed -i '/nvenc/,/vaapi/{s/scaleExtra: ""/scaleExtra: ":flags=lanczos"/}' server.js
+
+# 5. Desabilita wrapSwFilters (hwdownload/hwupload não necessários com CPU scale)
+sed -i 's/wrapSwFilters: \[ "hwdownload", "hwupload_cuda" \]/wrapSwFilters: !1/' server.js
+```
+
+**Lógica interna do server.js (para referência):**
+
+O server.js (por volta da linha 82560 no bundle webpack) tem esta lógica de filtros:
+- Se `accelConfig.scale` é truthy (ex: `"scale_cuda"`): usa filtros HW `scale_cuda=W:H:format=pixfmt`
+- Se `accelConfig.scale` é falsy (`!1`): usa filtros SW `scale=W:H:flags=lanczos,format=yuv420p`
+- Se `accelConfig.wrapSwFilters` é truthy (array): envolve filtros SW com `[hwdownload, ..., hwupload_cuda]`
+- Se `accelConfig.wrapSwFilters` é falsy (`!1`): filtros SW passam direto
+
+A seleção do perfil (por volta da linha 82535):
+```javascript
+!options.profile && userSettings.transcodeHardwareAccel &&
+  userSettings.transcodeProfile && (options.profile = userSettings.transcodeProfile);
+```
+Verifica `userSettings` **em memória**, não o arquivo — por isso o Patch 1 é essencial.
+
+### Configuração pré-aplicada no settings
+
+O entrypoint também configura o `server-settings.json` no disco como fallback:
+```bash
+sed -i \
   -e 's/"transcodeHardwareAccel": false/"transcodeHardwareAccel": true/' \
   -e 's/"transcodeProfile": null/"transcodeProfile": "nvenc-linux"/' \
   -e 's/"allTranscodeProfiles": \[\]/"allTranscodeProfiles": ["nvenc-linux"]/' \
-  /root/.stremio-server/server-settings.json
-
-# Reiniciar para aplicar
-docker compose -f compose.yaml restart
+  "$SETTINGS"
 ```
-
-### Monitorar uso de GPU durante streaming
-
-```bash
-# Tempo real
-watch -n1 "docker exec $(docker ps --filter 'ancestor=stremio-docker:nvidia' -q) nvidia-smi"
-```
-
-> **Nota:** A GPU só é usada quando há transcoding (ex: HEVC→H264, mudança de resolução). Se o player suporta o codec nativo, o stream vai direto sem ffmpeg.
-
-### Perfil nvenc-linux (pipeline ffmpeg)
-
-O perfil `nvenc-linux` é patcheado em runtime pelo entrypoint para compatibilidade 10-bit (Pascal/GTX 1070):
-
-- **Decode:** `hevc_cuvid`, `h264_cuvid`, `av1_cuvid` (GPU — ffmpeg auto-downloads para memória sistema)
-- **Scale:** CPU `scale` com lanczos (necessário para 10-bit → 8-bit)
-- **Encode:** `h264_nvenc` preset p1, tune ull (GPU — aceita frames de memória sistema)
-- **Args:** `-hwaccel cuda`
-
-Pipeline: HW decode (CUVID) → auto-download → CPU scale/format → NVENC encode
-
-> **Nota sobre 10-bit:** O GTX 1070 (Pascal) não suporta encode H.264 10-bit via NVENC.
-> O perfil original usava `scale_cuda` + `hwaccel_output_format cuda` que mantém frames 10-bit
-> em memória CUDA, causando falha no encoder. O patch remove esses flags e usa CPU scale
-> para converter 10-bit → 8-bit antes do encode.
 
 ## Rebuild / Atualização
 
@@ -195,16 +346,20 @@ docker compose -f compose.yaml up -d
 # 4. Aguardar inicialização (~10s)
 sleep 10
 
-# 5. Verificar GPU + patches
+# 5. Verificar patches aplicados (deve aparecer mensagem NVENC)
 docker logs stremio-docker-stremio-1 2>&1 | grep NVENC
+
+# 6. Verificar GPU visível
 docker exec $(docker ps --filter "ancestor=stremio-docker:nvidia" -q) nvidia-smi
 
-# 6. Verificar settings
+# 7. Verificar settings
 docker exec $(docker ps --filter "ancestor=stremio-docker:nvidia" -q) \
   grep -E 'transcodeHardware|transcodeProfile' /root/.stremio-server/server-settings.json
 ```
 
-> **Nota:** O entrypoint patcha `server.js` automaticamente a cada restart — não é mais necessário re-aplicar settings manualmente.
+> **Nota:** O entrypoint patcha `server.js` automaticamente a cada restart — não é necessário
+> re-aplicar settings ou patches manualmente. Isso é o ponto-chave do design: o server.js
+> original é preservado na imagem Docker, e os patches são aplicados em runtime.
 
 ### Atualizar versão CUDA
 
@@ -217,24 +372,234 @@ FROM nvidia/cuda:<VERSION>-devel-ubuntu22.04 AS ffmpeg
 FROM nvidia/cuda:<VERSION>-runtime-ubuntu22.04 AS final
 ```
 
-Também verificar compatibilidade de `nv-codec-headers` (branch no git clone).
+Também verificar compatibilidade de `nv-codec-headers` (branch no git clone, linha 21-24).
 
-## Correções aplicadas (vs Dockerfile original)
+---
 
-| Problema | Correção | Arquivo |
-|---|---|---|
-| `nvcc fatal: Unsupported gpu architecture 'compute_30'` | `--nvccflags="-gencode arch=compute_52,code=sm_52 -O2"` | Dockerfile.nvidia |
-| `cuvid requested, but not all dependencies are satisfied: ffnvcodec` | Instalação de `nv-codec-headers n12.0.16.1` | Dockerfile.nvidia |
-| `getpwnam("nginx") failed` | `useradd -r -s /bin/false nginx` | Dockerfile.nvidia |
-| `libwebpmux.so.3: cannot open` | Adicionado `libwebpmux3` aos pacotes | Dockerfile.nvidia |
-| `Bad substitution` (dash vs bash) | `case` POSIX em vez de `${var: -1}` | stremio-web-service-run.sh |
-| Teste hwaccel falha (sample curto) | Patch `server.js`: `transcodeHardwareAccel:!1` → `!0` | stremio-web-service-run.sh |
-| 10-bit NVENC fail (Pascal GPU) | Patch perfil: remove `scale_cuda`/`hwaccel_output_format`, usa CPU scale | stremio-web-service-run.sh |
+## O que NÃO funcionou (lições aprendidas)
+
+Esta seção documenta todas as abordagens que foram tentadas e falharam, com explicação de
+**por que** falharam. **NÃO tente essas abordagens novamente.**
+
+### ❌ Approach 1: File watcher para manter settings
+
+**Ideia:** Um script em background monitora `server-settings.json` e reverte
+`transcodeHardwareAccel` para `true` sempre que o Stremio gravar `false`.
+
+**Implementação tentada:**
+```bash
+# Background subshell monitorando o arquivo
+(while [ "$SECONDS" -lt 360 ]; do
+  if grep -q '"transcodeHardwareAccel": false' "$SETTINGS"; then
+    sed -i 's/"transcodeHardwareAccel": false/"transcodeHardwareAccel": true/' "$SETTINGS"
+  fi
+  sleep 2
+done) &
+```
+
+**Por que falhou:**
+1. **Timeout insuficiente:** Primeiro tentou com 90s, mas o auto-test leva ~132s para completar
+2. **Não resolve o problema real:** Mesmo com timeout de 360s e o arquivo corrigido,
+   o **processo node** já leu o valor em memória. O `saveSettings()` do Stremio atualiza:
+   - `userSettings` (objeto JavaScript em memória) → **não afetado por editar o arquivo**
+   - `server-settings.json` (disco) → corrigido pelo watcher, mas irrelevante
+3. **O ffmpeg continuava usando `libx264`** (software) em vez de `h264_nvenc` porque
+   a seleção de perfil verifica `userSettings.transcodeHardwareAccel` em memória
+
+**Conclusão:** Editar o arquivo de settings depois que o node já iniciou é inútil.
+A solução tem que ser no código do server.js, antes da execução.
+
+### ❌ Approach 2: Patch `initialDetection = false` no server.js
+
+**Ideia:** Desabilitar o flag `initialDetection` no módulo de auto-teste do server.js
+para que ele nunca rode o teste inicial.
+
+**Implementação tentada:**
+```bash
+sed -i 's/var initialDetection = !0/var initialDetection = !1/' server.js
+```
+
+**Por que falhou:**
+O auto-teste do Stremio tem **dois caminhos de execução**:
+1. `initialDetection = true` → roda na startup (SEM callback)
+2. Chamado com callback (`expectResult = !!cb = true`) → roda quando o transcoding é ativado
+
+O patch desabilitava apenas o caminho 1. O caminho 2 ainda executava o teste
+e chamava `saveSettings({transcodeHardwareAccel: !1})`.
+
+**Conclusão:** Não basta desabilitar o teste — precisa neutralizar o `saveSettings` que
+grava o valor `false`. A solução correta é trocar `!1` por `!0` em TODAS as chamadas
+`saveSettings({transcodeHardwareAccel: ...})`.
+
+### ❌ Approach 3: `scale_cuda=format=nv12` para converter 10-bit na GPU
+
+**Ideia:** Usar o filtro `scale_cuda` com opção `format=nv12` para converter frames
+de p010le (10-bit) para nv12 (8-bit) inteiramente na GPU, sem download para CPU.
+
+**Implementação tentada:**
+```bash
+ffmpeg -hwaccel cuda -hwaccel_output_format cuda -c:v hevc_cuvid \
+  -i input.mkv -vf "scale_cuda=1920:1080:format=nv12" -c:v h264_nvenc output.mp4
+```
+
+**Por que falhou:**
+O ffmpeg nesta build (jellyfin-ffmpeg 4.4.1-4) **não suporta a opção `format` no
+`scale_cuda`**. O filtro só aceita `w:h` sem conversão de pixel format:
+```
+Option format not found.
+```
+
+Versões mais recentes do ffmpeg (5.x+) e builds customizadas podem suportar
+`scale_cuda=format=nv12`, mas a 4.4.x não.
+
+**Conclusão:** Seria a solução ideal (100% GPU), mas requer atualizar o ffmpeg para 5.x+
+ou usar uma build com suporte. Com jellyfin-ffmpeg 4.4.1-4, não é possível.
+
+### ❌ Approach 4: `hwdownload,format=nv12` para baixar como 8-bit
+
+**Ideia:** Baixar frames CUDA para system memory já convertendo para nv12 (8-bit)
+usando o filtro `hwdownload` seguido de `format=nv12`.
+
+**Implementação tentada:**
+```bash
+ffmpeg -hwaccel cuda -hwaccel_output_format cuda -c:v hevc_cuvid \
+  -i input.mkv -vf "hwdownload,format=nv12,scale=1920:1080" -c:v h264_nvenc output.mp4
+```
+
+**Por que falhou:**
+O `hwdownload` requer que o formato de saída corresponda **exatamente** ao formato
+dos frames CUDA. Frames HEVC 10-bit em CUDA estão em `p010le`, não `nv12`:
+```
+Discrepancy between hardware pixel format (cuda) and target pixel format (nv12)
+```
+
+A sequência correta seria `hwdownload,format=p010le,format=nv12` — mas isso é
+exatamente o que a remoção de `-hwaccel_output_format cuda` faz automaticamente
+(ffmpeg auto-downloads e o CPU scale converte transparentemente).
+
+**Conclusão:** Rota mais complexa e frágil. Remover `-hwaccel_output_format cuda`
+é mais simples e produz o mesmo resultado — ffmpeg faz o download automaticamente.
+
+### ❌ Approach 5: Forçar settings via `server-settings.json` antes do startup
+
+**Ideia:** Configurar `server-settings.json` com os valores corretos antes de iniciar
+o `node server.js`, esperando que o node leia esses valores.
+
+**O que acontece na prática:**
+1. O entrypoint configura o arquivo com `transcodeHardwareAccel: true` ✅
+2. O `node server.js` inicia e lê o arquivo ✅
+3. O auto-test executa ~132s depois ⏳
+4. O auto-test falha e chama `saveSettings({transcodeHardwareAccel: false})` ❌
+5. O valor em memória volta para `false` ❌
+6. Todos os requests de transcoding subsequentes usam software encoding ❌
+
+**Conclusão:** Configurar o arquivo é necessário mas não suficiente. O auto-test
+sobrescreve o valor em memória. **Sempre combinar** com o patch do server.js.
+
+---
+
+## Correções aplicadas (resumo)
+
+| # | Problema | Sintoma | Causa Raiz | Correção | Arquivo |
+|---|----------|---------|------------|----------|---------|
+| 1 | CUDA 12.x build fail | `Unsupported gpu architecture 'compute_30'` | CUDA 12.x removeu compute_30 | `--nvccflags="-gencode arch=compute_52,code=sm_52 -O2"` | Dockerfile.nvidia |
+| 2 | NVENC/CUVID não compila | `ffnvcodec not satisfied` | Falta nv-codec-headers | Clone `nv-codec-headers n12.0.16.1` + `make install` | Dockerfile.nvidia |
+| 3 | nginx crash | `getpwnam("nginx") failed` | Ubuntu não cria user nginx | `useradd -r -s /bin/false nginx` | Dockerfile.nvidia |
+| 4 | Runtime lib faltando | `libwebpmux.so.3 not found` | Pacote separado no Ubuntu 22.04 | `apt install libwebpmux3` | Dockerfile.nvidia |
+| 5 | Entrypoint crash | `Bad substitution` | `dash` (POSIX sh) vs `bash` | `case` POSIX em vez de `${var: -1}` | stremio-web-service-run.sh |
+| 6 | GPU não usada | ffmpeg usa `libx264` | Auto-test falha e desabilita hwaccel | `sed 's/transcodeHardwareAccel: !1/!0/g'` | stremio-web-service-run.sh |
+| 7 | Vídeo HTTP 500 | `10 bit encode not supported` | Pascal não faz NVENC 10-bit H.264 | Remove `hwaccel_output_format cuda`, usa CPU scale | stremio-web-service-run.sh |
+
+## Referência técnica
+
+### Arquitetura NVENC por geração de GPU
+
+| Geração | Exemplos | H.264 8-bit | H.264 10-bit | HEVC 8-bit | HEVC 10-bit |
+|---------|----------|-------------|--------------|------------|-------------|
+| Maxwell (2ª gen) | GTX 950-980 | ✅ | ❌ | ✅ | ❌ |
+| **Pascal** | **GTX 1070, 1080** | **✅** | **❌** | **✅** | **❌** |
+| Turing | RTX 2070, 2080 | ✅ | ❌ | ✅ | ✅ |
+| Ampere | RTX 3070, 3080 | ✅ | ❌ | ✅ | ✅ |
+| Ada Lovelace | RTX 4070, 4090 | ✅ | ❌ | ✅ | ✅ |
+
+> **Nota:** H.264 10-bit NVENC não é suportado em **nenhuma geração**. O problema
+> é específico para quando o **input** é 10-bit e os frames ficam em memória CUDA
+> sem conversão para 8-bit antes do encode.
+>
+> GPUs Turing+ suportam HEVC 10-bit encode, então poderiam usar `scale_cuda` para
+> converter e encodar em HEVC. Mas o Stremio usa H.264 como output target.
+
+### Localização dos patches no server.js (bundle webpack)
+
+Estes offsets são aproximados e podem mudar entre versões do stremio-web:
+
+| Patch | Localização aprox. | Padrão no minificado |
+|-------|-------------------|---------------------|
+| Auto-test disable | ~linha 71936, 71962 | `saveSettings({transcodeHardwareAccel: !1})` |
+| Profile selection | ~linha 82535 | `userSettings.transcodeHardwareAccel && userSettings.transcodeProfile` |
+| Filter chain logic | ~linha 82560 | `accelConfig.scale`, `accelConfig.wrapSwFilters` |
+| nvenc-linux profile | ~linha 82480 | `profile: "nvenc-linux"`, `scale: "scale_cuda"` |
+
+> **Para verificar após atualização do stremio-web:**
+> ```bash
+> grep -n "transcodeHardwareAccel" server.js | head -10
+> grep -n "scale_cuda" server.js | head -5
+> grep -n "nvenc-linux" server.js | head -5
+> ```
+
+### Comandos úteis de diagnóstico
+
+```bash
+CONTAINER=$(docker ps --filter "ancestor=stremio-docker:nvidia" -q)
+
+# Ver todos os processos ffmpeg e seus argumentos
+docker exec $CONTAINER sh -c 'for pid in $(pgrep ffmpeg); do
+  echo "=== PID $pid ($(ps -o rss= -p $pid | awk "{printf \"%.0fMB\", \$1/1024}") RSS) ==="
+  cat /proc/$pid/cmdline | tr "\0" " "
+  echo -e "\n"
+done'
+
+# Verificar se patches foram aplicados
+docker exec $CONTAINER grep -c 'transcodeHardwareAccel: !0' server.js
+# Deve retornar 3 (2 que eram !1 + 1 original que já era !0)
+
+# Verificar se scale_cuda foi removido do perfil nvenc
+docker exec $CONTAINER grep -c 'scale_cuda' server.js
+# Deve retornar 0 (todos removidos)
+
+# Ver settings atuais em memória (via API do Stremio)
+curl -s http://localhost:11470/settings 2>/dev/null | python3 -m json.tool | grep -E 'transcode|Hardware'
+
+# GPU monitoring contínuo
+watch -n1 "docker exec $CONTAINER nvidia-smi --query-gpu=utilization.gpu,utilization.encoder,utilization.decoder,memory.used --format=csv,noheader"
+```
 
 ## Ambiente atual
 
 - **Host:** DietPi Linux, 4 CPUs, 15GB RAM
-- **GPU:** NVIDIA GeForce GTX 1070 (8GB VRAM)
+- **GPU:** NVIDIA GeForce GTX 1070 (8GB VRAM, Pascal, compute 6.1)
 - **Driver:** 535.288.01 / CUDA 12.2
-- **Volume:** `/mnt/lvm1-storage/.stremio-server` (2.7TB, 755GB livre)
+- **Docker runtime:** nvidia (nvidia-container-toolkit)
+- **Volume:** `/mnt/lvm1-storage/.stremio-server`
 - **Acesso:** `https://stremio.raspberrypi.lan/` (porta 8085)
+- **Branch git:** `test/gpu-nvidia`
+
+### Limites atuais do container
+
+| Recurso | Limite | Reserva | Justificativa |
+|---------|--------|---------|---------------|
+| CPU | 1.5 cores | — | NVENC offload (pico medido: 138%) |
+| RAM | 1536 MB | 256 MB | Pico medido: 1.35 GB |
+| GPU | 1x GTX 1070 | — | Decode + encode |
+
+### Commits (branch test/gpu-nvidia)
+
+```
+44f6233 perf: reduce container limits — NVENC offloads to GPU
+f869494 docs: update NVIDIA-GPU.md with 10-bit compat and auto-patch info
+2ba78fd fix: patch nvenc-linux profile for 10-bit compat (Pascal GPUs)
+a8d74c5 fix: neutralize hw accel auto-test by patching saveSettings calls
+b6db603 fix: patch server.js to skip broken hw accel auto-test
+2ecfd3e fix: extend NVENC watcher to 360s (auto-test takes ~2min)
+e321aca feat: NVIDIA GPU hardware acceleration (NVENC/NVDEC/CUVID)
+```

--- a/compose.simple.yaml
+++ b/compose.simple.yaml
@@ -1,0 +1,19 @@
+services:
+  stremio:
+    build:
+      context: .
+      dockerfile: Dockerfile.nvidia
+    image: local/stremio-simple:latest
+    restart: unless-stopped
+    environment:
+      - NO_CORS=1
+      - AUTO_SERVER_URL=0
+      - IPADDRESS=192.168.0.100
+      - SERVER_URL=https://192.168.0.100:8085
+      - WEBUI_INTERNAL_PORT=8080
+    ports:
+      - "8085:8080"
+    volumes:
+      - "/mnt/lvm1-storage/.stremio-server:/root/.stremio-server"
+    # Usar o NVIDIA Container Runtime
+    runtime: nvidia

--- a/compose.yaml
+++ b/compose.yaml
@@ -18,11 +18,16 @@ services:
       - "8085:8080"
     volumes:
       - "/mnt/lvm1-storage/.stremio-server:/root/.stremio-server"
+    extra_hosts:
+      - "stremio.raspberrypi.lan:192.168.0.100"
+      - "raspberrypi.lan:192.168.0.100"
     deploy:
       resources:
         limits:
+          cpus: "2.0"
           memory: 2G
         reservations:
+          memory: 512M
           devices:
             - driver: nvidia
               count: 1

--- a/compose.yaml
+++ b/compose.yaml
@@ -24,10 +24,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "2.0"
-          memory: 2G
+          cpus: "1.5"
+          memory: 1536M
         reservations:
-          memory: 512M
+          memory: 256M
           devices:
             - driver: nvidia
               count: 1

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,10 +3,21 @@ services:
     image: tsaridas/stremio-docker:latest
     restart: unless-stopped
     environment:
-      NO_CORS: 1
-      AUTO_SERVER_URL: 1
-      #IPADDRESS: 192.168.1.10 # Setup your ip address here
+      - NO_CORS=1
+      - AUTO_SERVER_URL=0
+      - IPADDRESS=192.168.0.100
+      - SERVER_URL=https://stremio.raspberrypi.lan/
+      - WEBUI_INTERNAL_PORT=8080
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=compute,video,utility
     ports:
-      - "8080:8080"
+      - "8085:8080"
     volumes:
-      - "./stremio-data:/root/.stremio-server"
+      - "/mnt/lvm1-storage/.stremio-server:/root/.stremio-server"
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "1"
+        reservations:
+          memory: 64M

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,10 @@
 services:
   stremio:
-    image: tsaridas/stremio-docker:latest
+    build:
+      context: .
+      dockerfile: Dockerfile.nvidia
+    image: stremio-docker:nvidia
+    runtime: nvidia
     restart: unless-stopped
     environment:
       - NO_CORS=1
@@ -17,7 +21,9 @@ services:
     deploy:
       resources:
         limits:
-          memory: 512M
-          cpus: "1"
+          memory: 2G
         reservations:
-          memory: 64M
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu, video, compute]

--- a/stremio-web-service-run.sh
+++ b/stremio-web-service-run.sh
@@ -7,9 +7,9 @@ HTPASSWD_FILE="/etc/nginx/.htpasswd"
 sed -i 's/df -k/df -Pk/g' server.js
 
 if [ -n "${SERVER_URL}" ]; then
-    if [ "${SERVER_URL: -1}" != "/" ]; then
+    case "$SERVER_URL" in */) ;; *)
         SERVER_URL="$SERVER_URL/"
-    fi
+    ;; esac
     cp localStorage.json build/localStorage.json
     touch build/server_url.env
     sed -i "s|http://127.0.0.1:11470/|"${SERVER_URL}"|g" build/localStorage.json
@@ -53,4 +53,35 @@ elif [ -n "${CERT_FILE}" ]; then
     fi
 fi
 node server.js &
+SERVER_PID=$!
+
+# Force NVENC hw accel: pre-set and watch for auto-test reset
+if [ -f /usr/bin/nvidia-smi ] 2>/dev/null; then
+    SETTINGS="${CONFIG_FOLDER}server-settings.json"
+    # Pre-set before test runs
+    if [ -f "$SETTINGS" ]; then
+        sed -i \
+            -e 's/"transcodeHardwareAccel": false/"transcodeHardwareAccel": true/' \
+            -e 's/"transcodeProfile": null/"transcodeProfile": "nvenc-linux"/' \
+            -e 's/"allTranscodeProfiles": \[\]/"allTranscodeProfiles": ["nvenc-linux"]/' \
+            "$SETTINGS"
+    fi
+    # Watch for auto-test resetting it back to false
+    (
+        set +e
+        for i in $(seq 1 90); do
+            sleep 1
+            if grep -q '"transcodeHardwareAccel": false' "$SETTINGS" 2>/dev/null; then
+                sed -i \
+                    -e 's/"transcodeHardwareAccel": false/"transcodeHardwareAccel": true/' \
+                    -e 's/"transcodeProfile": null/"transcodeProfile": "nvenc-linux"/' \
+                    -e 's/"allTranscodeProfiles": \[\]/"allTranscodeProfiles": ["nvenc-linux"]/' \
+                    "$SETTINGS"
+                echo "NVENC hardware acceleration re-applied after auto-test"
+                break
+            fi
+        done
+    ) &
+fi
+
 start_http_server

--- a/stremio-web-service-run.sh
+++ b/stremio-web-service-run.sh
@@ -66,10 +66,11 @@ if [ -f /usr/bin/nvidia-smi ] 2>/dev/null; then
             -e 's/"allTranscodeProfiles": \[\]/"allTranscodeProfiles": ["nvenc-linux"]/' \
             "$SETTINGS"
     fi
-    # Watch for auto-test resetting it back to false
+    # Watch for auto-test resetting it back to false (test can take up to 5 min)
     (
         set +e
-        for i in $(seq 1 90); do
+        FIXED=0
+        for i in $(seq 1 360); do
             sleep 1
             if grep -q '"transcodeHardwareAccel": false' "$SETTINGS" 2>/dev/null; then
                 sed -i \
@@ -77,10 +78,14 @@ if [ -f /usr/bin/nvidia-smi ] 2>/dev/null; then
                     -e 's/"transcodeProfile": null/"transcodeProfile": "nvenc-linux"/' \
                     -e 's/"allTranscodeProfiles": \[\]/"allTranscodeProfiles": ["nvenc-linux"]/' \
                     "$SETTINGS"
-                echo "NVENC hardware acceleration re-applied after auto-test"
+                echo "NVENC hardware acceleration re-applied after auto-test (iteration $i)"
+                FIXED=1
                 break
             fi
         done
+        if [ "$FIXED" -eq 0 ]; then
+            echo "NVENC watcher: settings stayed true (no auto-test reset detected)"
+        fi
     ) &
 fi
 

--- a/stremio-web-service-run.sh
+++ b/stremio-web-service-run.sh
@@ -59,11 +59,21 @@ if [ -f /usr/bin/nvidia-smi ] 2>/dev/null; then
     SETTINGS="${CONFIG_FOLDER}server-settings.json"
 
     # Patch server.js: prevent auto-test from disabling hw accel
-    # The auto-test always fails (0.2s sample + concurrency race condition).
-    # Change saveSettings({transcodeHardwareAccel: false}) to true,
-    # so test failures don't disable GPU transcoding.
     sed -i 's/transcodeHardwareAccel: !1/transcodeHardwareAccel: !0/g' server.js
-    echo "NVENC: patched server.js — hw accel cannot be disabled by auto-test"
+
+    # Patch nvenc-linux profile for 10-bit compatibility (GTX 1070 / Pascal):
+    # 1. Remove -hwaccel_output_format cuda (forces 10-bit CUDA frames → NVENC fails)
+    sed -i 's/"-hwaccel", "cuda", "-hwaccel_output_format", "cuda"/"-hwaccel", "cuda"/' server.js
+    # 2. Remove -init_hw_device/-filter_hw_device (only needed for scale_cuda)
+    sed -i 's/"-init_hw_device", "cuda=cu:0", "-filter_hw_device", "cu", "-hwaccel"/"-hwaccel"/' server.js
+    # 3. Use CPU scale instead of scale_cuda (CUDA frames auto-downloaded by ffmpeg)
+    sed -i 's/scale: "scale_cuda"/scale: !1/' server.js
+    # 4. Restore lanczos scaler flags for CPU scale
+    sed -i '/nvenc/,/vaapi/{s/scaleExtra: ""/scaleExtra: ":flags=lanczos"/}' server.js
+    # 5. Disable wrapSwFilters (no hwdownload/hwupload needed with CPU scale)
+    sed -i 's/wrapSwFilters: \[ "hwdownload", "hwupload_cuda" \]/wrapSwFilters: !1/' server.js
+
+    echo "NVENC: patched server.js (auto-test + 10-bit compat + CPU scale)"
 
     # Set NVENC settings in config file
     if [ -f "$SETTINGS" ]; then

--- a/stremio-web-service-run.sh
+++ b/stremio-web-service-run.sh
@@ -58,9 +58,12 @@ fi
 if [ -f /usr/bin/nvidia-smi ] 2>/dev/null; then
     SETTINGS="${CONFIG_FOLDER}server-settings.json"
 
-    # Patch server.js: disable hw accel auto-detection (always fails on short sample)
-    sed -i 's/initialDetection = process.env.HLS_DEBUG || userSettings.transcodeHardwareAccel && !(userSettings.allTranscodeProfiles || \[\]).length/initialDetection = false/' server.js
-    echo "NVENC: patched server.js to skip hw accel auto-test"
+    # Patch server.js: prevent auto-test from disabling hw accel
+    # The auto-test always fails (0.2s sample + concurrency race condition).
+    # Change saveSettings({transcodeHardwareAccel: false}) to true,
+    # so test failures don't disable GPU transcoding.
+    sed -i 's/transcodeHardwareAccel: !1/transcodeHardwareAccel: !0/g' server.js
+    echo "NVENC: patched server.js — hw accel cannot be disabled by auto-test"
 
     # Set NVENC settings in config file
     if [ -f "$SETTINGS" ]; then

--- a/stremio-web-service-run.sh
+++ b/stremio-web-service-run.sh
@@ -52,41 +52,28 @@ elif [ -n "${CERT_FILE}" ]; then
         node certificate.js --action load --pem-path "/srv/stremio-server/certificates.pem" --domain "${DOMAIN}" --json-path "${CONFIG_FOLDER}httpsCert.json"
     fi
 fi
-node server.js &
-SERVER_PID=$!
-
-# Force NVENC hw accel: pre-set and watch for auto-test reset
+# Force NVENC hw accel: patch server.js to skip the broken auto-test
+# The auto-test always fails (0.2s sample + concurrency race) and disables hw accel.
+# We disable the test and set correct NVENC settings directly.
 if [ -f /usr/bin/nvidia-smi ] 2>/dev/null; then
     SETTINGS="${CONFIG_FOLDER}server-settings.json"
-    # Pre-set before test runs
+
+    # Patch server.js: disable hw accel auto-detection (always fails on short sample)
+    sed -i 's/initialDetection = process.env.HLS_DEBUG || userSettings.transcodeHardwareAccel && !(userSettings.allTranscodeProfiles || \[\]).length/initialDetection = false/' server.js
+    echo "NVENC: patched server.js to skip hw accel auto-test"
+
+    # Set NVENC settings in config file
     if [ -f "$SETTINGS" ]; then
         sed -i \
             -e 's/"transcodeHardwareAccel": false/"transcodeHardwareAccel": true/' \
             -e 's/"transcodeProfile": null/"transcodeProfile": "nvenc-linux"/' \
             -e 's/"allTranscodeProfiles": \[\]/"allTranscodeProfiles": ["nvenc-linux"]/' \
             "$SETTINGS"
+        echo "NVENC: settings configured (transcodeHardwareAccel: true, profile: nvenc-linux)"
     fi
-    # Watch for auto-test resetting it back to false (test can take up to 5 min)
-    (
-        set +e
-        FIXED=0
-        for i in $(seq 1 360); do
-            sleep 1
-            if grep -q '"transcodeHardwareAccel": false' "$SETTINGS" 2>/dev/null; then
-                sed -i \
-                    -e 's/"transcodeHardwareAccel": false/"transcodeHardwareAccel": true/' \
-                    -e 's/"transcodeProfile": null/"transcodeProfile": "nvenc-linux"/' \
-                    -e 's/"allTranscodeProfiles": \[\]/"allTranscodeProfiles": ["nvenc-linux"]/' \
-                    "$SETTINGS"
-                echo "NVENC hardware acceleration re-applied after auto-test (iteration $i)"
-                FIXED=1
-                break
-            fi
-        done
-        if [ "$FIXED" -eq 0 ]; then
-            echo "NVENC watcher: settings stayed true (no auto-test reset detected)"
-        fi
-    ) &
 fi
+
+node server.js &
+SERVER_PID=$!
 
 start_http_server


### PR DESCRIPTION
This pull request introduces a new NVIDIA GPU-accelerated Docker build and updates the deployment configuration to enable hardware-accelerated video transcoding with ffmpeg NVENC support for Stremio. It includes a new `Dockerfile.nvidia`, updates to both Docker Compose files to use the new image and runtime, and patches to the startup script to ensure hardware acceleration is correctly enabled and configured. These changes are aimed at improving video transcoding performance by leveraging NVIDIA GPUs.

**NVIDIA GPU-accelerated Docker build and deployment:**

* Added a new `Dockerfile.nvidia` that builds ffmpeg with CUDA/NVENC support and sets up a multi-stage Docker image for Stremio with NVIDIA runtime compatibility.
* Updated `compose.yaml` and added `compose.simple.yaml` to use the new NVIDIA-enabled Dockerfile, set up the container to run with the NVIDIA runtime, and configured environment variables and resource constraints for GPU usage. [[1]](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cL3-R34) [[2]](diffhunk://#diff-e1c1e9c3b5d304146d74d19d9e7b419c411aa3c19d2b60930c93c1d335833f6aR1-R19)

**Hardware acceleration and compatibility improvements:**

* Modified `stremio-web-service-run.sh` to patch `server.js` at runtime, ensuring NVENC hardware acceleration is always enabled, disables the unreliable auto-test, and fixes compatibility issues for 10-bit video and CPU scaling with NVIDIA GPUs.
* Improved handling of the `SERVER_URL` variable in `stremio-web-service-run.sh` for more robust URL formatting.