### PR TITLE
fix build by pinning pnpm for Node 20 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ WORKDIR /srv/stremio-web
 COPY ./load_localStorage.js ./src/load_localStorage.js
 RUN sed -i "/entry: {/a \\        loader: './src/load_localStorage.js'," webpack.config.js
 
-RUN npm install -g pnpm --force
+RUN npm install -g pnpm@9 --force
 RUN pnpm install --frozen-lockfile --reporter=silent
 RUN pnpm run build
 


### PR DESCRIPTION
Pin pnpm to v9 in the Docker build stage so GitHub Actions no longer installs a Node 22-only pnpm release that fails under node:20-alpine.