### PR TITLE
fix github actions node24 deprecation warnings

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -32,7 +32,7 @@ jobs:
           - linux/ppc64le
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare
         run: |
@@ -42,13 +42,13 @@ jobs:
           echo "TAG=${{ env.TMP_LOCAL_IMAGE }}:${platform//\//-}" >> $GITHUB_ENV
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -235,7 +235,7 @@ jobs:
           docker rm "$CONTAINER_ID"
 
       - name: Upload image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: images-${{ strategy.job-index }}
           path: /tmp/images/${{ env.TARFILE }}
@@ -253,7 +253,7 @@ jobs:
           - 5000:5000
     steps:
       - name: Download images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: images-*
           merge-multiple: true
@@ -267,7 +267,7 @@ jobs:
         run: |
           docker push -a ${{ env.TMP_LOCAL_IMAGE }}
       - name: Login to GitHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -9,6 +9,7 @@ permissions:
   packages: write
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   TMP_LOCAL_IMAGE: localhost:5000/${{ github.repository }}
   REGISTRY: ghcr.io
   REGISTRY_IMAGE: ${{ github.repository }}

--- a/.github/workflows/publish-hub-nightly.yml
+++ b/.github/workflows/publish-hub-nightly.yml
@@ -6,6 +6,7 @@ on:
     - cron: "0 0 * * *"
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   TMP_LOCAL_IMAGE: localhost:5000/${{ github.repository }}
   REGISTRY_IMAGE: ${{ github.repository }}
   REGISTRY_TAG: nightly

--- a/.github/workflows/publish-hub-nightly.yml
+++ b/.github/workflows/publish-hub-nightly.yml
@@ -26,7 +26,7 @@ jobs:
           - linux/ppc64le
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare
         run: |
@@ -36,13 +36,13 @@ jobs:
           echo "TAG=${{ env.TMP_LOCAL_IMAGE }}:${platform//\//-}" >> $GITHUB_ENV
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -229,7 +229,7 @@ jobs:
           docker rm "$CONTAINER_ID"
 
       - name: Upload image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: images-${{ strategy.job-index }}
           path: /tmp/images/${{ env.TARFILE }}
@@ -247,7 +247,7 @@ jobs:
           - 5000:5000
     steps:
       - name: Download images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: images-*
           merge-multiple: true
@@ -261,7 +261,7 @@ jobs:
         run: |
           docker push -a ${{ env.TMP_LOCAL_IMAGE }}
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASS }}

--- a/.github/workflows/publish-hub-release.yml
+++ b/.github/workflows/publish-hub-release.yml
@@ -16,6 +16,7 @@ on:
       - "Dockerfile"
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   TMP_LOCAL_IMAGE: localhost:5000/${{ github.repository }}
   REGISTRY_IMAGE: ${{ github.repository }}
   TAG_NAME: ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }}

--- a/.github/workflows/publish-hub-release.yml
+++ b/.github/workflows/publish-hub-release.yml
@@ -79,7 +79,7 @@ jobs:
           - linux/ppc64le
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare
         run: |
@@ -89,13 +89,13 @@ jobs:
           echo "TAG=${{ env.TMP_LOCAL_IMAGE }}:${platform//\//-}" >> $GITHUB_ENV
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -282,7 +282,7 @@ jobs:
           docker rm "$CONTAINER_ID"
 
       - name: Upload image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: images-${{ strategy.job-index }}
           path: /tmp/images/${{ env.TARFILE }}
@@ -302,7 +302,7 @@ jobs:
           - 5000:5000
     steps:
       - name: Download images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: images-*
           merge-multiple: true
@@ -319,7 +319,7 @@ jobs:
           docker push -a ${{ env.TMP_LOCAL_IMAGE }}
 
       - name: Login to DockerHUB
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASS }}
@@ -358,7 +358,7 @@ jobs:
       - check_release
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Release
         run: |
           TAG=$(git ls-remote --tags --refs ${{ env.WEBREPO }} | awk '{print $2}' | sort -V | tail -n1 | cut -d/ -f3)


### PR DESCRIPTION
Upgrade checkout, Docker, and artifact actions to newer major versions so workflows are compatible with the Node.js 24 runtime migration.