### PR TITLE
pin docker base image to latest node alpine version

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -267,7 +267,7 @@ jobs:
       - name: Push images to local registry
         run: |
           docker push -a ${{ env.TMP_LOCAL_IMAGE }}
-      - name: Login to GitHub
+      - name: Login to ghcr.io
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -85,7 +85,7 @@ jobs:
           docker exec "$CONTAINER_ID" ps aux
           docker logs "$CONTAINER_ID"
 
-          npx playwright test settings.spec --timeout=60000 || (
+          npx playwright test settings.spec --timeout=300000 || (
             docker ps -a;
             docker logs "$CONTAINER_ID";
             exit 1;
@@ -107,7 +107,7 @@ jobs:
           docker exec "$CONTAINER_ID" ps aux
           docker logs "$CONTAINER_ID"
 
-          SERVER_URL="http://172.18.0.3:11470" npx playwright test settings.spec --timeout=60000 || (
+          SERVER_URL="http://172.18.0.3:11470" npx playwright test settings.spec --timeout=300000 || (
             docker ps -a;
             docker logs "$CONTAINER_ID";
             exit 1;
@@ -129,13 +129,13 @@ jobs:
           docker exec "$CONTAINER_ID" ps aux
           docker logs "$CONTAINER_ID"
 
-          WEB_URL="https://172-18-0-3.519b6502d940.stremio.rocks:8080" SERVER_URL="https://172-18-0-3.519b6502d940.stremio.rocks:8080" npx playwright test settings.spec --timeout=60000 || (
+          WEB_URL="https://172-18-0-3.519b6502d940.stremio.rocks:8080" SERVER_URL="https://172-18-0-3.519b6502d940.stremio.rocks:8080" npx playwright test settings.spec --timeout=300000 || (
             docker ps -a;
             docker logs "$CONTAINER_ID";
             exit 1;
           )
           echo "--------------------------------"
-          WEB_URL="https://172-18-0-3.519b6502d940.stremio.rocks:8080" SERVER_URL="https://172-18-0-3.519b6502d940.stremio.rocks:12470" npx playwright test settings.spec --timeout=60000 || (
+          WEB_URL="https://172-18-0-3.519b6502d940.stremio.rocks:8080" SERVER_URL="https://172-18-0-3.519b6502d940.stremio.rocks:12470" npx playwright test settings.spec --timeout=300000 || (
             docker ps -a;
             docker logs "$CONTAINER_ID";
             exit 1;
@@ -158,7 +158,7 @@ jobs:
           docker exec "$CONTAINER_ID" ps aux
           docker logs "$CONTAINER_ID"
 
-          npx playwright test settings_server_url.spec --timeout=60000 || (
+          npx playwright test settings_server_url.spec --timeout=300000 || (
             docker ps -a;
             docker logs "$CONTAINER_ID";
             exit 1;
@@ -180,7 +180,7 @@ jobs:
           docker exec "$CONTAINER_ID" ps aux
           docker logs "$CONTAINER_ID"
     
-          npx playwright test settings_server_url.spec --timeout=60000 || (
+          npx playwright test settings_server_url.spec --timeout=300000 || (
             docker ps -a;
             docker logs "$CONTAINER_ID";
             exit 1;
@@ -202,7 +202,7 @@ jobs:
           docker exec "$CONTAINER_ID" ps aux
           docker logs "$CONTAINER_ID"
 
-          WEB_URL="http://172.18.0.3:9090" SERVER_URL="http://172.18.0.3:9090" npx playwright test settings.spec --timeout=60000 || (
+          WEB_URL="http://172.18.0.3:9090" SERVER_URL="http://172.18.0.3:9090" npx playwright test settings.spec --timeout=300000 || (
             docker ps -a;
             docker logs "$CONTAINER_ID";
             exit 1;
@@ -225,7 +225,7 @@ jobs:
           docker exec "$CONTAINER_ID" ps aux
           docker logs "$CONTAINER_ID"
   
-          AUTH=true npx playwright test settings.spec --timeout=60000 || (
+          AUTH=true npx playwright test settings.spec --timeout=300000 || (
             docker ps -a;
             docker logs "$CONTAINER_ID";
             exit 1;

--- a/.github/workflows/publish-hub-nightly.yml
+++ b/.github/workflows/publish-hub-nightly.yml
@@ -79,7 +79,7 @@ jobs:
           docker exec "$CONTAINER_ID" ps aux
           docker logs "$CONTAINER_ID"
 
-          npx playwright test settings.spec --timeout=60000 || (
+          npx playwright test settings.spec --timeout=300000 || (
             docker ps -a;
             docker logs "$CONTAINER_ID";
             exit 1;
@@ -101,7 +101,7 @@ jobs:
           docker exec "$CONTAINER_ID" ps aux
           docker logs "$CONTAINER_ID"
 
-          SERVER_URL="http://172.18.0.3:11470" npx playwright test settings.spec --timeout=60000 || (
+          SERVER_URL="http://172.18.0.3:11470" npx playwright test settings.spec --timeout=300000 || (
             docker ps -a;
             docker logs "$CONTAINER_ID";
             exit 1;
@@ -123,13 +123,13 @@ jobs:
           docker exec "$CONTAINER_ID" ps aux
           docker logs "$CONTAINER_ID"
 
-          WEB_URL="https://172-18-0-3.519b6502d940.stremio.rocks:8080" SERVER_URL="https://172-18-0-3.519b6502d940.stremio.rocks:8080" npx playwright test settings.spec --timeout=60000 || (
+          WEB_URL="https://172-18-0-3.519b6502d940.stremio.rocks:8080" SERVER_URL="https://172-18-0-3.519b6502d940.stremio.rocks:8080" npx playwright test settings.spec --timeout=300000 || (
             docker ps -a;
             docker logs "$CONTAINER_ID";
             exit 1;
           )
           echo "--------------------------------"
-          WEB_URL="https://172-18-0-3.519b6502d940.stremio.rocks:8080" SERVER_URL="https://172-18-0-3.519b6502d940.stremio.rocks:12470" npx playwright test settings.spec --timeout=60000 || (
+          WEB_URL="https://172-18-0-3.519b6502d940.stremio.rocks:8080" SERVER_URL="https://172-18-0-3.519b6502d940.stremio.rocks:12470" npx playwright test settings.spec --timeout=300000 || (
             docker ps -a;
             docker logs "$CONTAINER_ID";
             exit 1;
@@ -152,7 +152,7 @@ jobs:
           docker exec "$CONTAINER_ID" ps aux
           docker logs "$CONTAINER_ID"
 
-          npx playwright test settings_server_url.spec --timeout=60000 || (
+          npx playwright test settings_server_url.spec --timeout=300000 || (
             docker ps -a;
             docker logs "$CONTAINER_ID";
             exit 1;
@@ -174,7 +174,7 @@ jobs:
           docker exec "$CONTAINER_ID" ps aux
           docker logs "$CONTAINER_ID"
     
-          npx playwright test settings_server_url.spec --timeout=60000 || (
+          npx playwright test settings_server_url.spec --timeout=300000 || (
             docker ps -a;
             docker logs "$CONTAINER_ID";
             exit 1;
@@ -196,7 +196,7 @@ jobs:
           docker exec "$CONTAINER_ID" ps aux
           docker logs "$CONTAINER_ID"
 
-          WEB_URL="http://172.18.0.3:9090" SERVER_URL="http://172.18.0.3:9090" npx playwright test settings.spec --timeout=60000 || (
+          WEB_URL="http://172.18.0.3:9090" SERVER_URL="http://172.18.0.3:9090" npx playwright test settings.spec --timeout=300000 || (
             docker ps -a;
             docker logs "$CONTAINER_ID";
             exit 1;
@@ -219,7 +219,7 @@ jobs:
           docker exec "$CONTAINER_ID" ps aux
           docker logs "$CONTAINER_ID"
   
-          AUTH=true npx playwright test settings.spec --timeout=60000 || (
+          AUTH=true npx playwright test settings.spec --timeout=300000 || (
             docker ps -a;
             docker logs "$CONTAINER_ID";
             exit 1;

--- a/.github/workflows/publish-hub-release.yml
+++ b/.github/workflows/publish-hub-release.yml
@@ -132,7 +132,7 @@ jobs:
           docker exec "$CONTAINER_ID" ps aux
           docker logs "$CONTAINER_ID"
 
-          npx playwright test settings.spec --timeout=60000 || (
+          npx playwright test settings.spec --timeout=300000 || (
             docker ps -a;
             docker logs "$CONTAINER_ID";
             exit 1;
@@ -154,7 +154,7 @@ jobs:
           docker exec "$CONTAINER_ID" ps aux
           docker logs "$CONTAINER_ID"
 
-          SERVER_URL="http://172.18.0.3:11470" npx playwright test settings.spec --timeout=60000 || (
+          SERVER_URL="http://172.18.0.3:11470" npx playwright test settings.spec --timeout=300000 || (
             docker ps -a;
             docker logs "$CONTAINER_ID";
             exit 1;
@@ -176,13 +176,13 @@ jobs:
           docker exec "$CONTAINER_ID" ps aux
           docker logs "$CONTAINER_ID"
 
-          WEB_URL="https://172-18-0-3.519b6502d940.stremio.rocks:8080" SERVER_URL="https://172-18-0-3.519b6502d940.stremio.rocks:8080" npx playwright test settings.spec --timeout=60000 || (
+          WEB_URL="https://172-18-0-3.519b6502d940.stremio.rocks:8080" SERVER_URL="https://172-18-0-3.519b6502d940.stremio.rocks:8080" npx playwright test settings.spec --timeout=300000 || (
             docker ps -a;
             docker logs "$CONTAINER_ID";
             exit 1;
           )
           echo "--------------------------------"
-          WEB_URL="https://172-18-0-3.519b6502d940.stremio.rocks:8080" SERVER_URL="https://172-18-0-3.519b6502d940.stremio.rocks:12470" npx playwright test settings.spec --timeout=60000 || (
+          WEB_URL="https://172-18-0-3.519b6502d940.stremio.rocks:8080" SERVER_URL="https://172-18-0-3.519b6502d940.stremio.rocks:12470" npx playwright test settings.spec --timeout=300000 || (
             docker ps -a;
             docker logs "$CONTAINER_ID";
             exit 1;
@@ -205,7 +205,7 @@ jobs:
           docker exec "$CONTAINER_ID" ps aux
           docker logs "$CONTAINER_ID"
 
-          npx playwright test settings_server_url.spec --timeout=60000 || (
+          npx playwright test settings_server_url.spec --timeout=300000 || (
             docker ps -a;
             docker logs "$CONTAINER_ID";
             exit 1;
@@ -227,7 +227,7 @@ jobs:
           docker exec "$CONTAINER_ID" ps aux
           docker logs "$CONTAINER_ID"
     
-          npx playwright test settings_server_url.spec --timeout=60000 || (
+          npx playwright test settings_server_url.spec --timeout=300000 || (
             docker ps -a;
             docker logs "$CONTAINER_ID";
             exit 1;
@@ -249,7 +249,7 @@ jobs:
           docker exec "$CONTAINER_ID" ps aux
           docker logs "$CONTAINER_ID"
 
-          WEB_URL="http://172.18.0.3:9090" SERVER_URL="http://172.18.0.3:9090" npx playwright test settings.spec --timeout=60000 || (
+          WEB_URL="http://172.18.0.3:9090" SERVER_URL="http://172.18.0.3:9090" npx playwright test settings.spec --timeout=300000 || (
             docker ps -a;
             docker logs "$CONTAINER_ID";
             exit 1;
@@ -272,7 +272,7 @@ jobs:
           docker exec "$CONTAINER_ID" ps aux
           docker logs "$CONTAINER_ID"
   
-          AUTH=true npx playwright test settings.spec --timeout=60000 || (
+          AUTH=true npx playwright test settings.spec --timeout=300000 || (
             docker ps -a;
             docker logs "$CONTAINER_ID";
             exit 1;

--- a/Dockerfile
+++ b/Dockerfile
@@ -160,9 +160,7 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then \
   apk add --no-cache intel-media-driver mesa-va-gallium; \
   fi
 
-# Drop package managers: bytes live under /opt/yarn-v* and /usr/local/lib/node_modules
-# (npm/corepack trees). /usr/local/bin/yarn|npm|npx|corepack are only symlinks — remove
-# those too so nothing points at deleted paths. Runtime needs only /usr/local/bin/node.
+# Clean up package managers and docs.
 RUN rm -rf /opt/yarn-v* /usr/local/lib/node_modules \
   && rm -f /usr/local/bin/yarn /usr/local/bin/yarnpkg /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack \
   && rm -rf /usr/share/man/* /usr/share/doc/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN cd && \
   cd jellyfin-ffmpeg* && \
   PATH="$BIN:$PATH" && \
   ./configure --help && \
-  ./configure --bindir="$BIN" --disable-debug \
+  ./configure --bindir="$BIN" --disable-debug --disable-x86asm \
   --extra-cflags="-Wno-error -Wno-error=deprecated-declarations -Wno-error=discarded-qualifiers" \
   --prefix=/usr/lib/jellyfin-ffmpeg --extra-version=Jellyfin --disable-doc --disable-ffplay --disable-shared --disable-libxcb --disable-sdl2 --disable-xlib --enable-gpl --enable-version3 --enable-gmp --enable-gnutls --enable-libdrm --enable-libass --enable-libfreetype --enable-libfribidi --enable-libfontconfig --enable-libbluray --enable-libmp3lame --enable-libopus --enable-libtheora --enable-libvorbis --enable-libdav1d --enable-libwebp --enable-libvpx --enable-libx264 --enable-libx265  --enable-libzimg --enable-small --enable-nonfree --enable-libxvid --enable-libaom --enable-libfdk_aac --enable-vaapi --enable-hwaccel=h264_vaapi --enable-hwaccel=hevc_vaapi --toolchain=hardened && \
   make -j2 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ FROM base AS ffmpeg
 
 # We build our own ffmpeg since 4.X is the only one supported
 ENV BIN="/usr/bin"
+COPY ./patches/ffmpeg-mathops-binutils241.patch /tmp/ffmpeg-mathops-binutils241.patch
 RUN cd && \
   apk add --no-cache --virtual .build-dependencies \
   gnutls \
@@ -43,9 +44,10 @@ RUN cd && \
   cd "${DIR}" && \
   git clone --depth 1 --branch v4.4.1-4 https://github.com/jellyfin/jellyfin-ffmpeg.git && \
   cd jellyfin-ffmpeg* && \
+  patch -p1 < /tmp/ffmpeg-mathops-binutils241.patch && \
   PATH="$BIN:$PATH" && \
   ./configure --help && \
-  ./configure --bindir="$BIN" --disable-debug --disable-x86asm --disable-inline-asm \
+  ./configure --bindir="$BIN" --disable-debug \
   --extra-cflags="-Wno-error -Wno-error=deprecated-declarations -Wno-error=discarded-qualifiers" \
   --prefix=/usr/lib/jellyfin-ffmpeg --extra-version=Jellyfin --disable-doc --disable-ffplay --disable-shared --disable-libxcb --disable-sdl2 --disable-xlib --enable-gpl --enable-version3 --enable-gmp --enable-gnutls --enable-libdrm --enable-libass --enable-libfreetype --enable-libfribidi --enable-libfontconfig --enable-libbluray --enable-libmp3lame --enable-libopus --enable-libtheora --enable-libvorbis --enable-libdav1d --enable-libwebp --enable-libvpx --enable-libx264 --enable-libx265  --enable-libzimg --enable-small --enable-nonfree --enable-libxvid --enable-libaom --enable-libfdk_aac --enable-vaapi --enable-hwaccel=h264_vaapi --enable-hwaccel=hevc_vaapi --toolchain=hardened && \
   make -j2 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ RUN cd && \
   --prefix=/usr/lib/jellyfin-ffmpeg --extra-version=Jellyfin --disable-doc --disable-ffplay --disable-shared --disable-libxcb --disable-sdl2 --disable-xlib --enable-lto --enable-gpl --enable-version3 --enable-gmp --enable-gnutls --enable-libdrm --enable-libass --enable-libfreetype --enable-libfribidi --enable-libfontconfig --enable-libbluray --enable-libmp3lame --enable-libopus --enable-libtheora --enable-libvorbis --enable-libdav1d --enable-libwebp --enable-libvpx --enable-libx264 --enable-libx265  --enable-libzimg --enable-small --enable-nonfree --enable-libxvid --enable-libaom --enable-libfdk_aac --enable-vaapi --enable-hwaccel=h264_vaapi --enable-hwaccel=hevc_vaapi --toolchain=hardened $EXTRA_FFMPEG_FLAGS && \
   make -j2 && \
   make install && \
+  find /usr/lib/jellyfin-ffmpeg -name '*.a' -delete && rm -rf /usr/lib/jellyfin-ffmpeg/include && \
   make distclean && \
   rm -rf "${DIR}"  && \
   apk del --purge .build-dependencies
@@ -159,8 +160,12 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then \
   apk add --no-cache intel-media-driver mesa-va-gallium; \
   fi
 
-# Clear cache
-RUN rm -rf /var/cache/apk/* && rm -rf /tmp/*
+# Clear cache; drop package managers (runtime: node only) and bulky docs
+RUN rm -rf /opt/yarn-v* /usr/local/bin/yarn /usr/local/bin/yarnpkg \
+  && rm -rf /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/corepack \
+  && rm -f /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack \
+  && rm -rf /usr/share/man/* /usr/share/doc/* \
+  && rm -rf /var/cache/apk/* /tmp/*
 
 VOLUME ["/root/.stremio-server"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,8 @@ RUN cd && \
   cd jellyfin-ffmpeg* && \
   PATH="$BIN:$PATH" && \
   ./configure --help && \
-  ./configure --bindir="$BIN" --disable-debug --disable-werror \
+  ./configure --bindir="$BIN" --disable-debug \
+  --extra-cflags="-Wno-error -Wno-error=deprecated-declarations -Wno-error=discarded-qualifiers" \
   --prefix=/usr/lib/jellyfin-ffmpeg --extra-version=Jellyfin --disable-doc --disable-ffplay --disable-shared --disable-libxcb --disable-sdl2 --disable-xlib --enable-lto --enable-gpl --enable-version3 --enable-gmp --enable-gnutls --enable-libdrm --enable-libass --enable-libfreetype --enable-libfribidi --enable-libfontconfig --enable-libbluray --enable-libmp3lame --enable-libopus --enable-libtheora --enable-libvorbis --enable-libdav1d --enable-libwebp --enable-libvpx --enable-libx264 --enable-libx265  --enable-libzimg --enable-small --enable-nonfree --enable-libxvid --enable-libaom --enable-libfdk_aac --enable-vaapi --enable-hwaccel=h264_vaapi --enable-hwaccel=hevc_vaapi --toolchain=hardened && \
   make -j4 && \
   make install && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -160,10 +160,11 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then \
   apk add --no-cache intel-media-driver mesa-va-gallium; \
   fi
 
-# Clear cache; drop package managers (runtime: node only) and bulky docs
-RUN rm -rf /opt/yarn-v* /usr/local/bin/yarn /usr/local/bin/yarnpkg \
-  && rm -rf /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/corepack \
-  && rm -f /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack \
+# Drop package managers: bytes live under /opt/yarn-v* and /usr/local/lib/node_modules
+# (npm/corepack trees). /usr/local/bin/yarn|npm|npx|corepack are only symlinks — remove
+# those too so nothing points at deleted paths. Runtime needs only /usr/local/bin/node.
+RUN rm -rf /opt/yarn-v* /usr/local/lib/node_modules \
+  && rm -f /usr/local/bin/yarn /usr/local/bin/yarnpkg /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack \
   && rm -rf /usr/share/man/* /usr/share/doc/* \
   && rm -rf /var/cache/apk/* /tmp/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -152,7 +152,7 @@ COPY --from=ffmpeg /usr/bin/ffmpeg /usr/bin/ffprobe /usr/bin/
 COPY --from=ffmpeg /usr/lib/jellyfin-ffmpeg /usr/lib/
 
 # Add libs
-RUN apk add --no-cache libwebp libvorbis x265-libs x264-libs libass opus libgmpxx lame-libs gnutls libvpx libtheora libdrm libbluray zimg libdav1d aom-libs xvidcore fdk-aac libva curl
+RUN apk add --no-cache libwebp libwebpmux libvorbis x265-libs x264-libs libass opus libgmpxx lame-libs gnutls libvpx libtheora libdrm libbluray zimg libdav1d aom-libs xvidcore fdk-aac libva curl
 
 # Add arch specific libs
 RUN if [ "$(uname -m)" = "x86_64" ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN cd && \
   ./configure --bindir="$BIN" --disable-debug \
   --extra-cflags="-Wno-error -Wno-error=deprecated-declarations -Wno-error=discarded-qualifiers" \
   --prefix=/usr/lib/jellyfin-ffmpeg --extra-version=Jellyfin --disable-doc --disable-ffplay --disable-shared --disable-libxcb --disable-sdl2 --disable-xlib --enable-lto --enable-gpl --enable-version3 --enable-gmp --enable-gnutls --enable-libdrm --enable-libass --enable-libfreetype --enable-libfribidi --enable-libfontconfig --enable-libbluray --enable-libmp3lame --enable-libopus --enable-libtheora --enable-libvorbis --enable-libdav1d --enable-libwebp --enable-libvpx --enable-libx264 --enable-libx265  --enable-libzimg --enable-small --enable-nonfree --enable-libxvid --enable-libaom --enable-libfdk_aac --enable-vaapi --enable-hwaccel=h264_vaapi --enable-hwaccel=hevc_vaapi --toolchain=hardened $EXTRA_FFMPEG_FLAGS && \
-  make -j2 && \
+  make -j"$(nproc)" && \
   make install && \
   find /usr/lib/jellyfin-ffmpeg -name '*.a' -delete && rm -rf /usr/lib/jellyfin-ffmpeg/include && \
   make distclean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN cd && \
   cd jellyfin-ffmpeg* && \
   PATH="$BIN:$PATH" && \
   ./configure --help && \
-  ./configure --bindir="$BIN" --disable-debug --disable-x86asm \
+  ./configure --bindir="$BIN" --disable-debug --disable-x86asm --disable-inline-asm \
   --extra-cflags="-Wno-error -Wno-error=deprecated-declarations -Wno-error=discarded-qualifiers" \
   --prefix=/usr/lib/jellyfin-ffmpeg --extra-version=Jellyfin --disable-doc --disable-ffplay --disable-shared --disable-libxcb --disable-sdl2 --disable-xlib --enable-gpl --enable-version3 --enable-gmp --enable-gnutls --enable-libdrm --enable-libass --enable-libfreetype --enable-libfribidi --enable-libfontconfig --enable-libbluray --enable-libmp3lame --enable-libopus --enable-libtheora --enable-libvorbis --enable-libdav1d --enable-libwebp --enable-libvpx --enable-libx264 --enable-libx265  --enable-libzimg --enable-small --enable-nonfree --enable-libxvid --enable-libaom --enable-libfdk_aac --enable-vaapi --enable-hwaccel=h264_vaapi --enable-hwaccel=hevc_vaapi --toolchain=hardened && \
   make -j2 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN cd && \
   cd jellyfin-ffmpeg* && \
   PATH="$BIN:$PATH" && \
   ./configure --help && \
-  ./configure --bindir="$BIN" --disable-debug \
+  ./configure --bindir="$BIN" --disable-debug --disable-werror \
   --prefix=/usr/lib/jellyfin-ffmpeg --extra-version=Jellyfin --disable-doc --disable-ffplay --disable-shared --disable-libxcb --disable-sdl2 --disable-xlib --enable-lto --enable-gpl --enable-version3 --enable-gmp --enable-gnutls --enable-libdrm --enable-libass --enable-libfreetype --enable-libfribidi --enable-libfontconfig --enable-libbluray --enable-libmp3lame --enable-libopus --enable-libtheora --enable-libvorbis --enable-libdav1d --enable-libwebp --enable-libvpx --enable-libx264 --enable-libx265  --enable-libzimg --enable-small --enable-nonfree --enable-libxvid --enable-libaom --enable-libfdk_aac --enable-vaapi --enable-hwaccel=h264_vaapi --enable-hwaccel=hevc_vaapi --toolchain=hardened && \
   make -j4 && \
   make install && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN cd && \
   ./configure --help && \
   ./configure --bindir="$BIN" --disable-debug \
   --extra-cflags="-Wno-error -Wno-error=deprecated-declarations -Wno-error=discarded-qualifiers" \
-  --prefix=/usr/lib/jellyfin-ffmpeg --extra-version=Jellyfin --disable-doc --disable-ffplay --disable-shared --disable-libxcb --disable-sdl2 --disable-xlib --enable-gpl --enable-version3 --enable-gmp --enable-gnutls --enable-libdrm --enable-libass --enable-libfreetype --enable-libfribidi --enable-libfontconfig --enable-libbluray --enable-libmp3lame --enable-libopus --enable-libtheora --enable-libvorbis --enable-libdav1d --enable-libwebp --enable-libvpx --enable-libx264 --enable-libx265  --enable-libzimg --enable-small --enable-nonfree --enable-libxvid --enable-libaom --enable-libfdk_aac --enable-vaapi --enable-hwaccel=h264_vaapi --enable-hwaccel=hevc_vaapi --toolchain=hardened && \
+  --prefix=/usr/lib/jellyfin-ffmpeg --extra-version=Jellyfin --disable-doc --disable-ffplay --disable-shared --disable-libxcb --disable-sdl2 --disable-xlib --enable-lto --enable-gpl --enable-version3 --enable-gmp --enable-gnutls --enable-libdrm --enable-libass --enable-libfreetype --enable-libfribidi --enable-libfontconfig --enable-libbluray --enable-libmp3lame --enable-libopus --enable-libtheora --enable-libvorbis --enable-libdav1d --enable-libwebp --enable-libvpx --enable-libx264 --enable-libx265  --enable-libzimg --enable-small --enable-nonfree --enable-libxvid --enable-libaom --enable-libfdk_aac --enable-vaapi --enable-hwaccel=h264_vaapi --enable-hwaccel=hevc_vaapi --toolchain=hardened && \
   make -j2 && \
   make install && \
   make distclean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,9 +49,11 @@ RUN cd && \
   awk '/^diff --git /,0' /tmp/ffmpeg-mlpdsp-armv5te-binutils243.patch | patch -p1 && \
   PATH="$BIN:$PATH" && \
   ./configure --help && \
+  EXTRA_FFMPEG_FLAGS="" && \
+  case "$(uname -m)" in armv6l|armv7l|armhf) EXTRA_FFMPEG_FLAGS="--disable-vaapi --disable-hwaccel=h264_vaapi --disable-hwaccel=hevc_vaapi";; esac && \
   ./configure --bindir="$BIN" --disable-debug \
   --extra-cflags="-Wno-error -Wno-error=deprecated-declarations -Wno-error=discarded-qualifiers" \
-  --prefix=/usr/lib/jellyfin-ffmpeg --extra-version=Jellyfin --disable-doc --disable-ffplay --disable-shared --disable-libxcb --disable-sdl2 --disable-xlib --enable-lto --enable-gpl --enable-version3 --enable-gmp --enable-gnutls --enable-libdrm --enable-libass --enable-libfreetype --enable-libfribidi --enable-libfontconfig --enable-libbluray --enable-libmp3lame --enable-libopus --enable-libtheora --enable-libvorbis --enable-libdav1d --enable-libwebp --enable-libvpx --enable-libx264 --enable-libx265  --enable-libzimg --enable-small --enable-nonfree --enable-libxvid --enable-libaom --enable-libfdk_aac --enable-vaapi --enable-hwaccel=h264_vaapi --enable-hwaccel=hevc_vaapi --toolchain=hardened && \
+  --prefix=/usr/lib/jellyfin-ffmpeg --extra-version=Jellyfin --disable-doc --disable-ffplay --disable-shared --disable-libxcb --disable-sdl2 --disable-xlib --enable-lto --enable-gpl --enable-version3 --enable-gmp --enable-gnutls --enable-libdrm --enable-libass --enable-libfreetype --enable-libfribidi --enable-libfontconfig --enable-libbluray --enable-libmp3lame --enable-libopus --enable-libtheora --enable-libvorbis --enable-libdav1d --enable-libwebp --enable-libvpx --enable-libx264 --enable-libx265  --enable-libzimg --enable-small --enable-nonfree --enable-libxvid --enable-libaom --enable-libfdk_aac --enable-vaapi --enable-hwaccel=h264_vaapi --enable-hwaccel=hevc_vaapi --toolchain=hardened $EXTRA_FFMPEG_FLAGS && \
   make -j2 && \
   make install && \
   make distclean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # We use node:20-alpine3.18 because it's the only one that supports the build-base package for ffmpeg. Changing to 3.21 will require a new ffmpeg build.
-FROM node:26.1.0-alpine3.23 AS base
+FROM node:20-alpine3.23 AS base
 
 RUN apk update && apk upgrade
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,8 @@ RUN cd && \
   ./configure --help && \
   ./configure --bindir="$BIN" --disable-debug \
   --extra-cflags="-Wno-error -Wno-error=deprecated-declarations -Wno-error=discarded-qualifiers" \
-  --prefix=/usr/lib/jellyfin-ffmpeg --extra-version=Jellyfin --disable-doc --disable-ffplay --disable-shared --disable-libxcb --disable-sdl2 --disable-xlib --enable-lto --enable-gpl --enable-version3 --enable-gmp --enable-gnutls --enable-libdrm --enable-libass --enable-libfreetype --enable-libfribidi --enable-libfontconfig --enable-libbluray --enable-libmp3lame --enable-libopus --enable-libtheora --enable-libvorbis --enable-libdav1d --enable-libwebp --enable-libvpx --enable-libx264 --enable-libx265  --enable-libzimg --enable-small --enable-nonfree --enable-libxvid --enable-libaom --enable-libfdk_aac --enable-vaapi --enable-hwaccel=h264_vaapi --enable-hwaccel=hevc_vaapi --toolchain=hardened && \
-  make -j4 && \
+  --prefix=/usr/lib/jellyfin-ffmpeg --extra-version=Jellyfin --disable-doc --disable-ffplay --disable-shared --disable-libxcb --disable-sdl2 --disable-xlib --enable-gpl --enable-version3 --enable-gmp --enable-gnutls --enable-libdrm --enable-libass --enable-libfreetype --enable-libfribidi --enable-libfontconfig --enable-libbluray --enable-libmp3lame --enable-libopus --enable-libtheora --enable-libvorbis --enable-libdav1d --enable-libwebp --enable-libvpx --enable-libx264 --enable-libx265  --enable-libzimg --enable-small --enable-nonfree --enable-libxvid --enable-libaom --enable-libfdk_aac --enable-vaapi --enable-hwaccel=h264_vaapi --enable-hwaccel=hevc_vaapi --toolchain=hardened && \
+  make -j2 && \
   make install && \
   make distclean && \
   rm -rf "${DIR}"  && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# We use node:20-alpine3.18 because it's the only one that supports the build-base package for ffmpeg. Changing to 3.21 will require a new ffmpeg build.
+# Base: Node 20 on Alpine 3.23 (jellyfin-ffmpeg is patched for this Alpine/gcc toolchain).
 FROM node:20-alpine3.23 AS base
 
 RUN apk update && apk upgrade

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ FROM base AS ffmpeg
 # We build our own ffmpeg since 4.X is the only one supported
 ENV BIN="/usr/bin"
 COPY ./patches/ffmpeg-mathops-binutils241.patch /tmp/ffmpeg-mathops-binutils241.patch
+COPY ./patches/ffmpeg-mlpdsp-armv5te-binutils243.patch /tmp/ffmpeg-mlpdsp-armv5te-binutils243.patch
 RUN cd && \
   apk add --no-cache --virtual .build-dependencies \
   gnutls \
@@ -44,7 +45,8 @@ RUN cd && \
   cd "${DIR}" && \
   git clone --depth 1 --branch v4.4.1-4 https://github.com/jellyfin/jellyfin-ffmpeg.git && \
   cd jellyfin-ffmpeg* && \
-  patch -p1 < /tmp/ffmpeg-mathops-binutils241.patch && \
+  awk '/^diff --git /,0' /tmp/ffmpeg-mathops-binutils241.patch | patch -p1 && \
+  awk '/^diff --git /,0' /tmp/ffmpeg-mlpdsp-armv5te-binutils243.patch | patch -p1 && \
   PATH="$BIN:$PATH" && \
   ./configure --help && \
   ./configure --bindir="$BIN" --disable-debug \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # We use node:20-alpine3.18 because it's the only one that supports the build-base package for ffmpeg. Changing to 3.21 will require a new ffmpeg build.
-FROM node:20-alpine3.18 AS base
+FROM node:26.1.0-alpine3.23 AS base
 
 RUN apk update && apk upgrade
 

--- a/patches/ffmpeg-mathops-binutils241.patch
+++ b/patches/ffmpeg-mathops-binutils241.patch
@@ -1,0 +1,59 @@
+diff --git a/libavcodec/x86/mathops.h b/libavcodec/x86/mathops.h
+index 6298f5ed19..ca7e2dffc1 100644
+--- a/libavcodec/x86/mathops.h
++++ b/libavcodec/x86/mathops.h
+@@ -35,12 +35,20 @@
+ static av_always_inline av_const int MULL(int a, int b, unsigned shift)
+ {
+     int rt, dummy;
++    if (__builtin_constant_p(shift))
+     __asm__ (
+         "imull %3               \n\t"
+         "shrdl %4, %%edx, %%eax \n\t"
+         :"=a"(rt), "=d"(dummy)
+-        :"a"(a), "rm"(b), "ci"((uint8_t)shift)
++        :"a"(a), "rm"(b), "i"(shift & 0x1F)
+     );
++    else
++        __asm__ (
++            "imull %3               \n\t"
++            "shrdl %4, %%edx, %%eax \n\t"
++            :"=a"(rt), "=d"(dummy)
++            :"a"(a), "rm"(b), "c"((uint8_t)shift)
++        );
+     return rt;
+ }
+ 
+@@ -113,19 +121,31 @@ __asm__ volatile(\
+ // avoid +32 for shift optimization (gcc should do that ...)
+ #define NEG_SSR32 NEG_SSR32
+ static inline  int32_t NEG_SSR32( int32_t a, int8_t s){
++    if (__builtin_constant_p(s))
+     __asm__ ("sarl %1, %0\n\t"
+          : "+r" (a)
+-         : "ic" ((uint8_t)(-s))
++         : "i" (-s & 0x1F)
+     );
++    else
++        __asm__ ("sarl %1, %0\n\t"
++               : "+r" (a)
++               : "c" ((uint8_t)(-s))
++        );
+     return a;
+ }
+ 
+ #define NEG_USR32 NEG_USR32
+ static inline uint32_t NEG_USR32(uint32_t a, int8_t s){
++    if (__builtin_constant_p(s))
+     __asm__ ("shrl %1, %0\n\t"
+          : "+r" (a)
+-         : "ic" ((uint8_t)(-s))
++         : "i" (-s & 0x1F)
+     );
++    else
++        __asm__ ("shrl %1, %0\n\t"
++               : "+r" (a)
++               : "c" ((uint8_t)(-s))
++        );
+     return a;
+ }

--- a/patches/ffmpeg-mathops-binutils241.patch
+++ b/patches/ffmpeg-mathops-binutils241.patch
@@ -1,3 +1,12 @@
+# Source:
+# - FFmpeg cvslog: "avcodec/x86/mathops: clip constants used with shift instructions within inline assembly"
+#   https://ffmpeg.org/pipermail/ffmpeg-cvslog/2024-April/141961.html
+# - FFmpeg release/4.1 commit: 7ef6f317f8f90eb34d97e016af02905898827dc4
+#
+# Context:
+# - Fixes x86 inline asm shift operand failures with newer binutils (>= 2.41).
+# - Applied to jellyfin-ffmpeg v4.4.1-4 during Docker build.
+
 diff --git a/libavcodec/x86/mathops.h b/libavcodec/x86/mathops.h
 index 6298f5ed19..ca7e2dffc1 100644
 --- a/libavcodec/x86/mathops.h

--- a/patches/ffmpeg-mlpdsp-armv5te-binutils243.patch
+++ b/patches/ffmpeg-mlpdsp-armv5te-binutils243.patch
@@ -5,7 +5,8 @@
 # Context:
 # - Fixes ARMv5TE assembly label parsing failures on newer binutils.
 # - Applied to jellyfin-ffmpeg v4.4.1-4 during Docker build.
-
+diff --git a/libavcodec/arm/mlpdsp_armv5te.S b/libavcodec/arm/mlpdsp_armv5te.S
+index 41258ecf95..8f9a0f0f00 100644
 --- a/libavcodec/arm/mlpdsp_armv5te.S
 +++ b/libavcodec/arm/mlpdsp_armv5te.S
 @@ -229,7 +229,7 @@

--- a/patches/ffmpeg-mlpdsp-armv5te-binutils243.patch
+++ b/patches/ffmpeg-mlpdsp-armv5te-binutils243.patch
@@ -1,0 +1,38 @@
+# Source:
+# - FFmpeg cvslog: "libavcodec/arm/mlpdsp_armv5te: fix label format to work with binutils 2.43"
+#   https://ffmpeg.org/pipermail/ffmpeg-cvslog/2024-August/144996.html
+#
+# Context:
+# - Fixes ARMv5TE assembly label parsing failures on newer binutils.
+# - Applied to jellyfin-ffmpeg v4.4.1-4 during Docker build.
+
+diff --git a/libavcodec/arm/mlpdsp_armv5te.S b/libavcodec/arm/mlpdsp_armv5te.S
+--- a/libavcodec/arm/mlpdsp_armv5te.S
++++ b/libavcodec/arm/mlpdsp_armv5te.S
+@@ -229,7 +229,7 @@
+ .macro MLP_FILTER_CORE
+         mov             r12, #\offset
+         ldr             r3, [filter, r12]
+-01:
++1:
+         ldrsh           t, [sample_buffer], #2
+         ldr             c0, [state, r12]!
+         ldr             c1, [state, r12]!
+@@ -241,7 +241,7 @@
+         smlal           v2, f2, c2, t
+         smlal           v3, f3, c3, t
+         cmp             r12, #\offset_end
+-        bne             01b
++        bne             1b
+         ldr             c0, [state, r12]
+         ldr             c1, [state, r12, #4]
+         ldr             c2, [state, r12, #8]
+@@ -333,7 +333,7 @@
+         ldr             c2, [state], #4
+         smlal           v2, f2, c2, t
+         cmp             f3, #\idx
+-        bne             01b
++        bne             1b
+ 
+         mov             f0, #0
+         adc             f0, f0, f0

--- a/patches/ffmpeg-mlpdsp-armv5te-binutils243.patch
+++ b/patches/ffmpeg-mlpdsp-armv5te-binutils243.patch
@@ -10,29 +10,26 @@ diff --git a/libavcodec/arm/mlpdsp_armv5te.S b/libavcodec/arm/mlpdsp_armv5te.S
 --- a/libavcodec/arm/mlpdsp_armv5te.S
 +++ b/libavcodec/arm/mlpdsp_armv5te.S
 @@ -229,7 +229,7 @@
- .macro MLP_FILTER_CORE
-         mov             r12, #\offset
-         ldr             r3, [filter, r12]
+  // Begin loop
 -01:
 +1:
-         ldrsh           t, [sample_buffer], #2
-         ldr             c0, [state, r12]!
-         ldr             c1, [state, r12]!
+  .if TOTAL_TAPS == 0
+  // Things simplify a lot in this case
+  // In fact this could be pipelined further if it's worth it...
 @@ -241,7 +241,7 @@
-         smlal           v2, f2, c2, t
-         smlal           v3, f3, c3, t
-         cmp             r12, #\offset_end
--        bne             01b
-+        bne             1b
-         ldr             c0, [state, r12]
-         ldr             c1, [state, r12, #4]
-         ldr             c2, [state, r12, #8]
+  str ST0, [PST, #-4]!
+  str ST0, [PST, #4 * (MAX_BLOCKSIZE + MAX_FIR_ORDER)]
+  str ST0, [PSAMP], #4 * MAX_CHANNELS
+- bne 01b
++ bne 1b
+  .else
+  .if \fir_taps & 1
+  .set LOAD_REG, 1
 @@ -333,7 +333,7 @@
-         ldr             c2, [state], #4
-         smlal           v2, f2, c2, t
-         cmp             f3, #\idx
--        bne             01b
-+        bne             1b
+  str ST2, [PST, #4 * (MAX_BLOCKSIZE + MAX_FIR_ORDER)]
+  str ST3, [PSAMP], #4 * MAX_CHANNELS
+- bne 01b
++ bne 1b
  
-         mov             f0, #0
-         adc             f0, f0, f0
+  .endif
+  b 99f

--- a/patches/ffmpeg-mlpdsp-armv5te-binutils243.patch
+++ b/patches/ffmpeg-mlpdsp-armv5te-binutils243.patch
@@ -6,30 +6,32 @@
 # - Fixes ARMv5TE assembly label parsing failures on newer binutils.
 # - Applied to jellyfin-ffmpeg v4.4.1-4 during Docker build.
 
-diff --git a/libavcodec/arm/mlpdsp_armv5te.S b/libavcodec/arm/mlpdsp_armv5te.S
 --- a/libavcodec/arm/mlpdsp_armv5te.S
 +++ b/libavcodec/arm/mlpdsp_armv5te.S
 @@ -229,7 +229,7 @@
-  // Begin loop
+   .endif
+ 
+         // Begin loop
 -01:
 +1:
-  .if TOTAL_TAPS == 0
-  // Things simplify a lot in this case
-  // In fact this could be pipelined further if it's worth it...
+   .if TOTAL_TAPS == 0
+         // Things simplify a lot in this case
+         // In fact this could be pipelined further if it's worth it...
 @@ -241,7 +241,7 @@
-  str ST0, [PST, #-4]!
-  str ST0, [PST, #4 * (MAX_BLOCKSIZE + MAX_FIR_ORDER)]
-  str ST0, [PSAMP], #4 * MAX_CHANNELS
-- bne 01b
-+ bne 1b
-  .else
-  .if \fir_taps & 1
-  .set LOAD_REG, 1
+         str     ST0, [PST, #-4]!
+         str     ST0, [PST, #4 * (MAX_BLOCKSIZE + MAX_FIR_ORDER)]
+         str     ST0, [PSAMP], #4 * MAX_CHANNELS
+-        bne     01b
++        bne     1b
+   .else
+     .if \fir_taps & 1
+       .set LOAD_REG, 1
 @@ -333,7 +333,7 @@
-  str ST2, [PST, #4 * (MAX_BLOCKSIZE + MAX_FIR_ORDER)]
-  str ST3, [PSAMP], #4 * MAX_CHANNELS
-- bne 01b
-+ bne 1b
+         str     ST3, [PST, #-4]!
+         str     ST2, [PST, #4 * (MAX_BLOCKSIZE + MAX_FIR_ORDER)]
+         str     ST3, [PSAMP], #4 * MAX_CHANNELS
+-        bne     01b
++        bne     1b
+   .endif
+         b       99f
  
-  .endif
-  b 99f

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -1,6 +1,5 @@
 import { test as baseTest } from '@playwright/test';
 
-/** Streaming "Online" after adding a URL — slow on CI when the server runs hwaccel probes under QEMU (e.g. arm/v7). */
 export const streamingOnlineTimeoutMs = process.env.CI ? 240_000 : 15_000;
 
 type MyFixtures = {

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -1,5 +1,8 @@
 import { test as baseTest } from '@playwright/test';
 
+/** Streaming "Online" after adding a URL — slow on CI when the server runs hwaccel probes under QEMU (e.g. arm/v7). */
+export const streamingOnlineTimeoutMs = process.env.CI ? 240_000 : 15_000;
+
 type MyFixtures = {
   serverURL: string;
   webURL: string;

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { test } from './fixtures';
+import { streamingOnlineTimeoutMs, test } from './fixtures';
 
 const username = process.env.AUTH_USERNAME || 'default_user';
 const password = process.env.AUTH_PASSWORD || 'default_pass';
@@ -48,7 +48,7 @@ test.describe('Stremio API and Settings', () => {
     await page.getByPlaceholder('Enter URL').press('Enter');
     await page.getByRole('radio').nth(2).click(); 
 
-    await expect(page.getByText('Online')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Online')).toBeVisible({ timeout: streamingOnlineTimeoutMs });
     
     const serverUrlElement = page.getByText(serverURL);
     await expect(serverUrlElement).toBeVisible();

--- a/tests/e2e/settings_server_url.spec.ts
+++ b/tests/e2e/settings_server_url.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { test } from './fixtures';
+import { streamingOnlineTimeoutMs, test } from './fixtures';
 
 test.describe('Stremio API and Settings', () => {
   test('Automatically set streaming server URL', async ({ page, serverURL, webURL }) => {
@@ -8,7 +8,7 @@ test.describe('Stremio API and Settings', () => {
     
     await page.getByTitle('Streaming').click();
 
-    await expect(page.getByText('Online')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Online')).toBeVisible({ timeout: streamingOnlineTimeoutMs });
     
     const serverUrlElement = page.getByText(serverURL);
     await expect(serverUrlElement).toBeVisible();

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -2,19 +2,15 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: 'e2e',
-  /* QEMU emulated ARM jobs need far longer than amd64 (hwaccel self-tests, ffmpeg). */
   timeout: process.env.CI ? 300_000 : 60_000,
-  /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
+  /* Retry on CI */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     trace: 'on-first-retry',
   },

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -2,6 +2,8 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: 'e2e',
+  /* QEMU emulated ARM jobs need far longer than amd64 (hwaccel self-tests, ffmpeg). */
+  timeout: process.env.CI ? 300_000 : 60_000,
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */


### PR DESCRIPTION
Use an explicit Node and Alpine tag for reproducible builds while testing compatibility with newer base images.