### PR TITLE
fix(nginx): allow /{infoHash}/-1 + Dockerfile.nvidia Node 22/pnpm 11

### DIFF
--- a/Dockerfile.nvidia
+++ b/Dockerfile.nvidia
@@ -56,21 +56,21 @@ RUN cd && \
 
 #########################################################################
 
-# Builder image (same as original Dockerfile)
-FROM node:20-alpine3.23 AS builder-web
+# Builder image — stremio-web (development) currently requires Node >=22 and pnpm >=11
+FROM node:22-alpine AS builder-web
 
 WORKDIR /srv
 RUN apk add --no-cache git wget
 
 ARG BRANCH=development
-RUN REPO="https://github.com/Stremio/stremio-web.git"; if [ "$BRANCH" == "release" ];then git clone "$REPO" --depth 1 --branch $(git ls-remote --tags --refs $REPO | awk '{print $2}' | sort -V | tail -n1 | cut -d/ -f3); else git clone --depth 1 --branch "$BRANCH" https://github.com/Stremio/stremio-web.git; fi
+RUN REPO="https://github.com/Stremio/stremio-web.git"; if [ "$BRANCH" = "release" ]; then git clone "$REPO" --depth 1 --branch $(git ls-remote --tags --refs $REPO | awk '{print $2}' | sort -V | tail -n1 | cut -d/ -f3); else git clone --depth 1 --branch "$BRANCH" https://github.com/Stremio/stremio-web.git; fi
 
 WORKDIR /srv/stremio-web
 
 COPY ./load_localStorage.js ./src/load_localStorage.js
 RUN sed -i "/entry: {/a \\        loader: './src/load_localStorage.js'," webpack.config.js
 
-RUN npm install -g pnpm@9 --force
+RUN npm install -g pnpm@11 --force
 RUN pnpm install --frozen-lockfile --reporter=silent
 RUN pnpm run build
 

--- a/NVIDIA-GPU.md
+++ b/NVIDIA-GPU.md
@@ -530,6 +530,7 @@ overwrites the in-memory value. **Always combine** with the `server.js` patch.
 | 5 | Entrypoint crash | `Bad substitution` | `dash` (POSIX sh) vs `bash` | POSIX `case` instead of `${var: -1}` | stremio-web-service-run.sh |
 | 6 | GPU not used | ffmpeg uses `libx264` | Auto-test fails and disables hwaccel | `sed 's/transcodeHardwareAccel: !1/!0/g'` | stremio-web-service-run.sh |
 | 7 | Video HTTP 500 | `10 bit encode not supported` | Pascal cannot NVENC 10-bit H.264 | Remove `hwaccel_output_format cuda`, use CPU scale | stremio-web-service-run.sh |
+| 8 | Safari "Video Not Supported" / probe 500 | Lavf GET `/{infoHash}/-1` returns SPA `index.html` (1127 B) | nginx only matched `/([0-9]+)$`, not `-1` (addon `fileIdx: null`) | Allow optional sign: `(-?[0-9]+)` | nginx/http.d/default.conf, nginx/https.conf |
 
 ## Technical reference
 

--- a/nginx/http.d/default.conf
+++ b/nginx/http.d/default.conf
@@ -68,7 +68,10 @@ server {
         proxy_pass http://backend;
     }
 
-    location ~ "^/([a-zA-Z0-9]{40})/([0-9]+)$" {
+    # Allow -1 (Stremio "largest file" index when fileIdx is null from addons).
+    # Without this, /{infoHash}/-1 falls through to SPA index.html and HLS probe fails
+    # with "Video Not Supported" (Lavf receives 1127-byte HTML instead of MKV).
+    location ~ "^/([a-zA-Z0-9]{40})/(-?[0-9]+)$" {
         # doesn't work with auth
         # include /etc/nginx/auth.conf;
         proxy_pass http://backend;

--- a/nginx/https.conf
+++ b/nginx/https.conf
@@ -70,7 +70,10 @@ server {
         proxy_pass http://backend;
     }
 
-    location ~ "^/([a-zA-Z0-9]{40})/([0-9]+)$" {
+    # Allow -1 (Stremio "largest file" index when fileIdx is null from addons).
+    # Without this, /{infoHash}/-1 falls through to SPA index.html and HLS probe fails
+    # with "Video Not Supported" (Lavf receives 1127-byte HTML instead of MKV).
+    location ~ "^/([a-zA-Z0-9]{40})/(-?[0-9]+)$" {
         # doesn't work with auth
         # include /etc/nginx/auth.conf;
         proxy_pass http://backend;


### PR DESCRIPTION
## Summary

Follow-ups from testing the NVIDIA image in PR #148 (`ghcr.io/tsaridas/stremio-docker:pr-142-gpu-nvidia-nvidia`) on a **GTX 1070 (Pascal)** host.

This PR targets branch `pr-142-gpu-nvidia` so it can land into #148.

### 1. nginx: allow `/{infoHash}/-1` (blocker for many addon streams)

Addons often send `fileIdx: null`, so the client/server requests:

```text
/{40-char-infoHash}/-1
```

(`-1` = largest file). The previous location only matched non-negative indexes:

```nginx
location ~ "^/([a-zA-Z0-9]{40})/([0-9]+)$"
```

So `/-1` fell through to the SPA `try_files` → **`index.html`** (`text/html`). HLS probe (Lavf/ffprobe) then failed → `master.m3u8` **500** → player **Video Not Supported**.

**Fix:**

```nginx
location ~ "^/([a-zA-Z0-9]{40})/(-?[0-9]+)$"
```

Applied to both `nginx/http.d/default.conf` and `nginx/https.conf`. Documented as issue #8 in `NVIDIA-GPU.md`.

**Verified:** after the change, `/-1` returns `video/x-matroska` and HLS for `/-1` returns **200**.

### 2. Dockerfile.nvidia: Node 22 + pnpm 11

Current `stremio-web` (`development`) declares:

```json
"engines": { "node": ">=22", "pnpm": ">=11" }
```

Building with Node 20 + `pnpm@9` fails (`packages field missing or empty` against the current lockfile/workspace).

**Change:** builder stage uses `node:22-alpine` and `pnpm@11`. Also uses POSIX `=` in the `BRANCH` shell test (ash-compatible).

Full `docker build -f Dockerfile.nvidia` succeeds locally with these updates.

---

## Commits

1. `fix(nginx): allow infoHash file index -1 for addon streams`
2. `fix(Dockerfile.nvidia): Node 22 + pnpm 11 for current stremio-web`

## Test plan

- [ ] `docker build -f Dockerfile.nvidia .` completes (builder-web + ffmpeg + final)
- [ ] Play an addon stream with `fileIdx: null` (URL ends with `/-1`)
- [ ] Confirm probe / `master.m3u8` return **200** (not SPA HTML)
- [ ] Confirm streams with explicit `/0` still work
- [ ] Confirm NVENC still works (`h264_nvenc` / GPU under load) on Pascal or newer

## Notes (optional doc, not required for merge)

On some hosts, `runtime: nvidia` alone may not be enough for reliable NVENC; also declare GPU `devices` and/or `deploy.resources.reservations.devices` with `capabilities: [gpu, video, compute]`. The stock `compose-nvidia.yaml` already covers the reservation path.