### PR TITLE
fix(nginx): allow infoHash file index -1 for addon streams

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -17,8 +17,16 @@ jobs:
     name: Delete image from ghcr.io
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve package tag
+        id: tag
+        run: |
+          sanitize_path_segment() {
+            echo "$1" | sed 's/[^a-zA-Z0-9._-]/-/g' | sed 's/-\+/-/g' | sed 's/^-//;s/-$//'
+          }
+          RAW="${{ github.event.inputs.package-name || github.head_ref || github.ref_name }}"
+          echo "tag=$(sanitize_path_segment "$RAW")" >> "$GITHUB_OUTPUT"
       - uses: chipkent/action-cleanup-package@v1.0.1
         with:
           package-name: ${{ github.event.repository.name }}
-          tag: ${{ github.event.inputs.package-name  || github.head_ref || github.ref_name }}
+          tag: ${{ steps.tag.outputs.tag }}
           github-token: ${{ secrets.GH_DEL_PACK }}

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -13,7 +13,6 @@ env:
   TMP_LOCAL_IMAGE: localhost:5000/${{ github.repository }}
   REGISTRY: ghcr.io
   REGISTRY_IMAGE: ${{ github.repository }}
-  REGISTRY_TAG: ${{ github.head_ref || github.ref_name }} 
   VERSION: testing
   BRANCH: development
   TAG: 
@@ -273,6 +272,13 @@ jobs:
       - name: Push images to local registry
         run: |
           docker push -a ${{ env.TMP_LOCAL_IMAGE }}
+      - name: Sanitize registry tag
+        run: |
+          # Docker tags cannot contain '/' (branch names like fix/foo break imagetools).
+          sanitize_path_segment() {
+            echo "$1" | sed 's/[^a-zA-Z0-9._-]/-/g' | sed 's/-\+/-/g' | sed 's/^-//;s/-$//'
+          }
+          echo "REGISTRY_TAG=$(sanitize_path_segment "${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}")" >> "$GITHUB_ENV"
       - name: Login to ghcr.io
         uses: docker/login-action@v3
         with:
@@ -281,8 +287,15 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create manifest list and push
         run: |
-          docker buildx imagetools create -t ${{ env.REGISTRY }}/${{ env.REGISTRY_IMAGE }}:${{ env.REGISTRY_TAG }} \
-            $(docker image ls --format '{{.Repository}}:{{.Tag}}' '${{ env.TMP_LOCAL_IMAGE }}' | tr '\n' ' ')
+          SOURCES="$(docker image ls --format '{{.Repository}}:{{.Tag}}' '${{ env.TMP_LOCAL_IMAGE }}' | tr '\n' ' ')"
+          if [ -z "$(echo "$SOURCES" | tr -d '[:space:]')" ]; then
+            echo "No local images found for ${{ env.TMP_LOCAL_IMAGE }}"
+            docker image ls
+            exit 1
+          fi
+          echo "Creating manifest ${{ env.REGISTRY }}/${{ env.REGISTRY_IMAGE }}:${{ env.REGISTRY_TAG }}"
+          echo "Sources: $SOURCES"
+          docker buildx imagetools create -t "${{ env.REGISTRY }}/${{ env.REGISTRY_IMAGE }}:${{ env.REGISTRY_TAG }}" $SOURCES
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.REGISTRY_IMAGE }}:${{ env.REGISTRY_TAG }}

--- a/nginx/http.d/default.conf
+++ b/nginx/http.d/default.conf
@@ -73,7 +73,10 @@ server {
         proxy_pass http://backend;
     }
 
-    location ~ "^/([a-zA-Z0-9]{40})/([0-9]+)$" {
+    # Allow -1 (Stremio "largest file" index when fileIdx is null from addons).
+    # Without this, /{infoHash}/-1 falls through to SPA index.html and HLS probe fails
+    # with "Video Not Supported" (Lavf receives 1127-byte HTML instead of MKV).
+    location ~ "^/([a-zA-Z0-9]{40})/(-?[0-9]+)$" {
         # doesn't work with auth
         # include /etc/nginx/auth.conf;
         proxy_pass http://backend;

--- a/nginx/https.conf
+++ b/nginx/https.conf
@@ -76,7 +76,10 @@ server {
         proxy_pass http://backend;
     }
 
-    location ~ "^/([a-zA-Z0-9]{40})/([0-9]+)$" {
+    # Allow -1 (Stremio "largest file" index when fileIdx is null from addons).
+    # Without this, /{infoHash}/-1 falls through to SPA index.html and HLS probe fails
+    # with "Video Not Supported" (Lavf receives 1127-byte HTML instead of MKV).
+    location ~ "^/([a-zA-Z0-9]{40})/(-?[0-9]+)$" {
         # doesn't work with auth
         # include /etc/nginx/auth.conf;
         proxy_pass http://backend;


### PR DESCRIPTION
Addons often send fileIdx null, so clients request /{infoHash}/-1 (largest file). The previous location only matched non-negative indexes, so /-1 fell through to SPA index.html and HLS probe failed.